### PR TITLE
Fixed tag name in the documentation

### DIFF
--- a/docs/custom_constraints.md
+++ b/docs/custom_constraints.md
@@ -17,7 +17,7 @@ A example is:
 acme.form.rule.my_mapper:
     class: Acme\Form\Rule\MyRule
     tags:
-     - { name: validator.rule_mapper }
+     - { name: form_rule_constraint_mapper }
 ```
 
 After this you need to make sure you include your jquery validate rule into the page.


### PR DESCRIPTION
I noticed that a custom constraint I was making, wouldn't register somehow. So after some debugging  I found out the tag mentioned in the docs was out-of-date :)
The tagname was changed in commit 327c5c41f813311cf1021955e6ae1707729ffab4 file ExtensionPass.php