### PR TITLE
Symfony 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ phpunit.xml
 ### NodeJS ###
 ##############
 node_modules/
+
+### JQueryValidation ###
+########################
+/.tmp/

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_install:
 
 install:
   # Install composer dependencies
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source;
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction;
   # Install npm deps
   - if [ "$TEST_SCOPE" = "code" ]; then travis_retry npm install grunt-cli; fi;
   - if [ "$TEST_SCOPE" = "code" ]; then travis_retry npm install; fi;
@@ -88,5 +88,4 @@ after_failure:
 
 cache:
   directories:
-    - vendor
     - $HOME/.composer/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,42 @@ env:
 
 matrix:
   include:
-  - php: 5.6
-    env: |
-      - SYMFONY_VERSION=2.7.*
+  # [PHPUnit] Test symfony versions
   - php: 5.3.3
     env: |
       COMPOSER_FLAGS='--prefer-stable --prefer-lowest'
       PHPUNIT_COVERAGE='--coverage-text --coverage-clover=coverage.clover'
+  - php: 5.6
+    env: |
+      SYMFONY_VERSION=2.7.*
+  - php: 5.6
+    env: |
+      SYMFONY_VERSION=2.8.*
+  - php: 5.6
+    env: |
+      SYMFONY_VERSION=3.0.*
+  # [BEHAT] Test 2.8 without additionals in FF
   - php: 5.4
     env: |
+      SYMFONY_VERSION=2.8.*
       TEST_SCOPE='javascript'
       SYMFONY_ENVIRONMENT='test'
       SYMFONY__ENABLE_ADDITIONALS='false'
     addons:
       firefox: "42.0"
+  # [BEHAT] Test 2.3 with additionals in FF
+  - php: 5.4
+    env: |
+      SYMFONY_VERSION=2.3.*
+      TEST_SCOPE='javascript'
+      SYMFONY_ENVIRONMENT='test'
+      SYMFONY__ENABLE_ADDITIONALS='true'
+    addons:
+      firefox: "42.0"
+  # [BEHAT] Test 3.0 with additionals in FF
   - php: 5.6
     env: |
-      COMPOSER_FLAGS='--prefer-stable --prefer-lowest'
+      SYMFONY_VERSION=3.0.*
       TEST_SCOPE='javascript'
       SYMFONY_ENVIRONMENT='test'
       SYMFONY__ENABLE_ADDITIONALS='true'

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -8,21 +8,21 @@ default:
         - FeatureContext
         - Behat\MinkExtension\Context\MinkContext
       filters:
-        tags: ~@serverSide&&~@additionals&&~@basic
+        tags: "~@serverSide&&~@additionals&&~@basic"
     javascript_basic:
       paths: [ %paths.base%/tests/Functional/features ]
       contexts:
         - FeatureContext
         - Behat\MinkExtension\Context\MinkContext
       filters:
-        tags: @basic
+        tags: "@basic"
     javascript_additionals:
       paths: [ %paths.base%/tests/Functional/features ]
       contexts:
         - FeatureContext
         - Behat\MinkExtension\Context\MinkContext
       filters:
-        tags: @additionals
+        tags: "@additionals"
     server_side:
       paths: [ %paths.base%/tests/Functional/features ]
       contexts:
@@ -30,7 +30,7 @@ default:
           - serverSide: true
         - Behat\MinkExtension\Context\MinkContext
       filters:
-        tags: ~@clientSide
+        tags: "~@clientSide"
 
   extensions:
     Behat\MinkExtension:

--- a/composer.json
+++ b/composer.json
@@ -5,20 +5,21 @@
     "description": "Jquery form validation bundle for symfony 2",
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.3",
-        "symfony/dependency-injection": "~2.3",
-        "symfony/form": "~2.3, >=2.3.4",
-        "symfony/validator": "~2.3",
-        "symfony/twig-bundle": "~2.3",
-        "symfony/twig-bridge": "~2.3",
+        "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/dependency-injection": "~2.3|~3.0",
+        "symfony/form": "~2.3, >=2.3.5|~3.0",
+        "symfony/validator": "~2.3|~3.0",
+        "symfony/twig-bundle": "~2.3|~3.0",
+        "symfony/twig-bridge": "~2.3|~3.0",
         "twig/twig": "~1.14, >=1.14.2",
         "doctrine/collections": "~1.0"
     },
     "require-dev": {
-        "symfony/browser-kit": "~2.3",
-        "symfony/dom-crawler": "~2.3",
-        "symfony/finder": "~2.3",
-        "symfony/yaml": "~2.3",
+        "symfony/browser-kit": "~2.3|~3.0",
+        "symfony/dom-crawler": "~2.3|~3.0",
+        "symfony/finder": "~2.3|~3.0",
+        "symfony/yaml": "~2.3|~3.0",
+        "symfony/css-selector": "~2.3|~3.0",
 
         "phpunit/phpunit": "~4.7@stable",
         "symfony/phpunit-bridge": "~2.7@stable",
@@ -46,5 +47,6 @@
             "Tests\\Boekkooi\\Bundle\\JqueryValidationBundle\\": "tests/"
         }
     },
+    "prefer-stable": true,
     "minimum-stability": "dev"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,6 @@
 
 <phpunit colors="true" bootstrap="tests/bootstrap.php">
     <php>
-        <ini name="error_reporting" value="-1"/>
         <server name="KERNEL_DIR" value="tests/Functional/app" />
     </php>
 

--- a/src/Form/Extension/ButtonTypeExtension.php
+++ b/src/Form/Extension/ButtonTypeExtension.php
@@ -5,6 +5,7 @@ use Boekkooi\Bundle\JqueryValidationBundle\Form\FormRuleContextBuilder;
 use Boekkooi\Bundle\JqueryValidationBundle\Form\Util\FormHelper;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\ClickableInterface;
+use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 
@@ -35,7 +36,7 @@ class ButtonTypeExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return 'button';
+        return FormHelper::isSymfony3Compatible() ? ButtonType::class : 'button';
     }
 
     protected function hasRuleBuilderContext(FormView $view)

--- a/src/Form/Extension/FormTypeExtension.php
+++ b/src/Form/Extension/FormTypeExtension.php
@@ -10,6 +10,7 @@ use Boekkooi\Bundle\JqueryValidationBundle\Form\FormRuleProcessorInterface;
 use Boekkooi\Bundle\JqueryValidationBundle\Form\Util\FormHelper;
 use Boekkooi\Bundle\JqueryValidationBundle\Validator\ConstraintCollection;
 use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -150,7 +151,7 @@ class FormTypeExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return 'form';
+        return FormHelper::isSymfony3Compatible() ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
     }
 
     /**

--- a/src/Form/FormDataConstraintFinder.php
+++ b/src/Form/FormDataConstraintFinder.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Mapping\CascadingStrategy;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\MemberMetadata;
-use Symfony\Component\Validator\MetadataFactoryInterface;
+use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -21,8 +21,19 @@ class FormDataConstraintFinder
      */
     private $metadataFactory;
 
-    public function __construct(MetadataFactoryInterface $metadataFactory)
+    /**
+     * Constructor.
+     * @param MetadataFactoryInterface $metadataFactory
+     */
+    public function __construct($metadataFactory)
     {
+        if (
+            !$metadataFactory instanceof MetadataFactoryInterface &&
+            !$metadataFactory instanceof \Symfony\Component\Validator\MetadataFactoryInterface
+        ) {
+            throw new \InvalidArgumentException('metadataFactory must be a instanceof MetadataFactoryInterface');
+        }
+
         $this->metadataFactory = $metadataFactory;
     }
 
@@ -177,7 +188,7 @@ class FormDataConstraintFinder
 
         // Now locate the closest data class
         // TODO what is the length really for?
-        for ($i = $propertyPath->getLength(); $i != 0; $i--) {
+        for ($i = $propertyPath->getLength(); $i !== 0; $i--) {
             $dataForm = $dataForm->getParent();
 
             # When a data class is found then use that form
@@ -296,7 +307,7 @@ class FormDataConstraintFinder
             }
 
             $type = strtolower($constraint->type);
-            $type = $type == 'boolean' ? 'bool' : $constraint->type;
+            $type = $type === 'boolean' ? 'bool' : $constraint->type;
             $isFunction = 'is_' . $type;
             $ctypeFunction = 'ctype_' . $type;
             if (function_exists($isFunction) || function_exists($ctypeFunction)) {

--- a/src/Form/Rule/Mapping/MaxLengthRule.php
+++ b/src/Form/Rule/Mapping/MaxLengthRule.php
@@ -48,7 +48,13 @@ class MaxLengthRule implements ConstraintMapperInterface
             return false;
         }
 
-        return !($constraintClass === 'Symfony\Component\Validator\Constraints\Length' && $this->isType($form, 'choice'));
+        return !(
+            $constraintClass === 'Symfony\Component\Validator\Constraints\Length' &&
+            (FormHelper::isSymfony3Compatible() ?
+                $this->isType($form, 'Symfony\Component\Form\Extension\Core\Type\ChoiceType') :
+                $this->isType($form, 'choice')
+            )
+        );
     }
 
     protected function isType(FormInterface $type, $typeName)

--- a/src/Form/Rule/Mapping/MinLengthRule.php
+++ b/src/Form/Rule/Mapping/MinLengthRule.php
@@ -7,8 +7,11 @@ use Boekkooi\Bundle\JqueryValidationBundle\Form\Rule\ConstraintMapperInterface;
 use Boekkooi\Bundle\JqueryValidationBundle\Form\RuleCollection;
 use Boekkooi\Bundle\JqueryValidationBundle\Form\RuleMessage;
 use Boekkooi\Bundle\JqueryValidationBundle\Form\Util\FormHelper;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Constraints\Length;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -48,7 +51,13 @@ class MinLengthRule implements ConstraintMapperInterface
             return false;
         }
 
-        return !($constraintClass === 'Symfony\Component\Validator\Constraints\Length' && $this->isType($form, 'choice'));
+        return !(
+            $constraintClass === 'Symfony\Component\Validator\Constraints\Length' &&
+            (FormHelper::isSymfony3Compatible() ?
+                $this->isType($form, 'Symfony\Component\Form\Extension\Core\Type\ChoiceType') :
+                $this->isType($form, 'choice')
+            )
+        );
     }
 
     protected function isType(FormInterface $type, $typeName)

--- a/src/Form/Util/FormHelper.php
+++ b/src/Form/Util/FormHelper.php
@@ -14,12 +14,33 @@ use Symfony\Component\Validator\Constraint;
  */
 final class FormHelper
 {
+    public static function isSymfony3Compatible()
+    {
+        return method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
+    }
+
+    public static function isSymfony2Compatible()
+    {
+        return method_exists('Symfony\Component\Form\ResolvedFormTypeInterface', 'getName');
+    }
+
     public static function isType(ResolvedFormTypeInterface $type, $typeName)
     {
         do {
-            if ($type->getName() === $typeName) {
+            if (
+                self::isSymfony3Compatible() &&
+                get_class($type->getInnerType()) === $typeName
+            ) {
                 return true;
             }
+
+            if (
+                self::isSymfony2Compatible() &&
+                $type->getName() === $typeName
+            ) {
+                return true;
+            }
+
             $type = $type->getParent();
         } while ($type !== null);
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -11,17 +11,17 @@ services:
   boekkooi.jquery_validation.form.form_extension:
     class: %boekkooi.jquery_validation.form.form_extension.class%
     arguments:
-      - @boekkooi.jquery_validation.rule_processor
-      - @boekkooi.jquery_validation.rule_compiler
-      - @boekkooi.jquery_validation.constraint_finder
+      - "@boekkooi.jquery_validation.rule_processor"
+      - "@boekkooi.jquery_validation.rule_compiler"
+      - "@boekkooi.jquery_validation.constraint_finder"
       - %boekkooi.jquery_validation.enabled%
     tags:
-      - { name: form.type_extension, alias: form }
+      - { name: form.type_extension, alias: form, extended_type: Symfony\Component\Form\Extension\Core\Type\FormType }
 
   boekkooi.jquery_validation.form.button_extension:
     class: %boekkooi.jquery_validation.form.button_extension.class%
     tags:
-      - { name: form.type_extension, alias: button }
+      - { name: form.type_extension, alias: button, extended_type: Symfony\Component\Form\Extension\Core\Type\ButtonType }
 
   boekkooi.jquery_validation.rule_processor:
     class: %boekkooi.jquery_validation.rule_processor.class%
@@ -36,4 +36,4 @@ services:
   boekkooi.jquery_validation.constraint_finder:
     class: %boekkooi.jquery_validation.constraint_finder.class%
     arguments:
-      - @validator.mapping.class_metadata_factory
+      - "@validator.mapping.class_metadata_factory"

--- a/tests/Functional/BasicFormTest.php
+++ b/tests/Functional/BasicFormTest.php
@@ -64,16 +64,16 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"simple_form_data\"]");
+                var form = $("form[name=\"simple_data_form\"]");
                 var validator = form.validate({
                     rules: {
-                        "simple_form_data\x5Bname\x5D": {"required": true, "minlength": "2", "maxlength": "255"},
-                        "simple_form_data\x5Bpassword\x5D\x5Bfirst\x5D": {"required": true, "minlength": "2", "maxlength": "255"},
-                        "simple_form_data\x5Bpassword\x5D\x5Bsecond\x5D": {
+                        "simple_data_form\x5Bname\x5D": {"required": true, "minlength": "2", "maxlength": "255"},
+                        "simple_data_form\x5Bpassword\x5D\x5Bfirst\x5D": {"required": true, "minlength": "2", "maxlength": "255"},
+                        "simple_data_form\x5Bpassword\x5D\x5Bsecond\x5D": {
                             "equalTo": {
-                                param: "form[name=\"simple_form_data\"] *[name=\"simple_form_data[password][first]\"]",
+                                param: "form[name=\"simple_data_form\"] *[name=\"simple_data_form[password][first]\"]",
                                 depends: function () {
-                                    if (("simple_form_data\x5Bpassword\x5D\x5Bfirst\x5D" in validator.errorMap || "simple_form_data\x5Bpassword\x5D\x5Bfirst\x5D" in validator.invalid)) {
+                                    if (("simple_data_form\x5Bpassword\x5D\x5Bfirst\x5D" in validator.errorMap || "simple_data_form\x5Bpassword\x5D\x5Bfirst\x5D" in validator.invalid)) {
                                         return false;
                                     }
                                     return true;
@@ -82,17 +82,17 @@ class BasicFormTest extends FormTestCase
                         }
                     },
                     messages: {
-                        "simple_form_data\x5Bname\x5D": {
+                        "simple_data_form\x5Bname\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x202\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x20255\x20characters\x20or\x20less."
                         },
-                        "simple_form_data\x5Bpassword\x5D\x5Bfirst\x5D": {
+                        "simple_data_form\x5Bpassword\x5D\x5Bfirst\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x202\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x20255\x20characters\x20or\x20less."
                         },
-                        "simple_form_data\x5Bpassword\x5D\x5Bsecond\x5D": {"equalTo": "This\x20value\x20is\x20not\x20valid."}
+                        "simple_data_form\x5Bpassword\x5D\x5Bsecond\x5D": {"equalTo": "This\x20value\x20is\x20not\x20valid."}
                     }
                 });
             })(jQuery);',
@@ -109,10 +109,10 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"buttons\"]");
+                var form = $("form[name=\"buttons_form\"]");
                 var validator = form.validate({
                     rules: {
-                        "buttons\x5Btitle\x5D": {
+                        "buttons_form\x5Btitle\x5D": {
                             "required": {
                                 depends: function () {
                                     return (validator.settings.validation_groups["main"] || validator.settings.validation_groups["Default"]);
@@ -129,7 +129,7 @@ class BasicFormTest extends FormTestCase
                                 }
                             }
                         },
-                        "buttons\x5Bcontent\x5D": {
+                        "buttons_form\x5Bcontent\x5D": {
                             "required": {
                                 depends: function () {
                                     return (validator.settings.validation_groups["Default"]);
@@ -138,26 +138,27 @@ class BasicFormTest extends FormTestCase
                         }
                     },
                     messages: {
-                        "buttons\x5Btitle\x5D": {
+                        "buttons_form\x5Btitle\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x208\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x20200\x20characters\x20or\x20less."
-                        }, "buttons\x5Bcontent\x5D": {"required": "This\x20value\x20should\x20not\x20be\x20blank."}
+                        },
+                        "buttons_form\x5Bcontent\x5D": {"required": "This\x20value\x20should\x20not\x20be\x20blank."}
                     }
                 });
 
                 validator.settings.validation_groups = {"Default": false, "main": false};
 
-                form.find("*[name=\"buttons\x5BdefaultValidation\x5D\"]").click(function () {
+                form.find("*[name=\"buttons_form\x5BdefaultValidation\x5D\"]").click(function () {
                     validator.settings.validation_groups = {"Default": true, "main": false};
                 });
-                form.find("*[name=\"buttons\x5BmainValidation\x5D\"]").click(function () {
+                form.find("*[name=\"buttons_form\x5BmainValidation\x5D\"]").click(function () {
                     validator.settings.validation_groups = {"Default": false, "main": true};
                 });
-                form.find("*[name=\"buttons\x5BmainAndDefaultValidation\x5D\"]").click(function () {
+                form.find("*[name=\"buttons_form\x5BmainAndDefaultValidation\x5D\"]").click(function () {
                     validator.settings.validation_groups = {"Default": true, "main": true};
                 });
-                form.find("*[name=\"buttons\x5BnoValidation\x5D\"]").addClass("cancel");
+                form.find("*[name=\"buttons_form\x5BnoValidation\x5D\"]").addClass("cancel");
             })(jQuery);',
             $javascript
         );
@@ -175,10 +176,10 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"collection\"]");
+                var form = $("form[name=\"collection_with_groups_form\\"]");
                 var validator = form.validate({
                     rules: {
-                        "collection\x5Btitle\x5D": {
+                        "collection_with_groups_form\\x5Btitle\x5D": {
                             "required": {
                                 depends: function () {
                                     return (validator.settings.validation_groups["Default"]);
@@ -197,7 +198,7 @@ class BasicFormTest extends FormTestCase
                         }
                     },
                     messages: {
-                        "collection\x5Btitle\x5D": {
+                        "collection_with_groups_form\\x5Btitle\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x208\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x20200\x20characters\x20or\x20less."
@@ -205,10 +206,10 @@ class BasicFormTest extends FormTestCase
                     }
                 });
                 validator.settings.validation_groups = {"Default": false, "main": false};
-                form.find("*[name=\"collection\x5BdefaultValidation\x5D\"]").click(function () {
+                form.find("*[name=\"collection_with_groups_form\\x5BdefaultValidation\x5D\"]").click(function () {
                     validator.settings.validation_groups = {"Default": true, "main": false};
                 });
-                form.find("*[name=\"collection\x5BmainValidation\x5D\"]").click(function () {
+                form.find("*[name=\"collection_with_groups_form\\x5BmainValidation\x5D\"]").click(function () {
                     validator.settings.validation_groups = {"Default": false, "main": true};
                 });
             })(jQuery);',
@@ -221,9 +222,9 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"collection\"]");
+                var form = $("form[name=\"collection_with_groups_form\\"]");
                 var validator = form.validate();
-                form.find("*[name=\"collection\x5Btags\x5D\x5Btag__name__\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_with_groups_form\\x5Btags\x5D\x5Btag__name__\x5D\"]").rules("add", {
                     "required": {
                         depends: function () {
                             return (validator.settings.validation_groups["Default"]);
@@ -264,10 +265,10 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"collection\"]");
-                var validator = form.validate({rules: {"collection\x5Btitle\x5D": {"required": true, "minlength": 8, "maxlength": 200}},
+                var form = $("form[name=\"collection_form\"]");
+                var validator = form.validate({rules: {"collection_form\x5Btitle\x5D": {"required": true, "minlength": 8, "maxlength": 200}},
                     messages: {
-                        "collection\x5Btitle\x5D": {
+                        "collection_form\x5Btitle\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x208\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x20200\x20characters\x20or\x20less."
@@ -284,9 +285,9 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"collection\"]");
+                var form = $("form[name=\"collection_form\"]");
                 var validator = form.validate();
-                form.find("*[name=\"collection\x5Btags\x5D\x5Btag__name__\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_form\x5Btags\x5D\x5Btag__name__\x5D\"]").rules("add", {
                     "required": true,
                     "messages": {"required": "This\x20value\x20should\x20not\x20be\x20blank."}
                 });
@@ -307,10 +308,10 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"collection_compound\"]");
-                var validator = form.validate({rules: {"collection_compound\x5Btitle\x5D": {"required": true, "minlength": 8, "maxlength": 200}},
+                var form = $("form[name=\"collection_compound_form\"]");
+                var validator = form.validate({rules: {"collection_compound_form\x5Btitle\x5D": {"required": true, "minlength": 8, "maxlength": 200}},
                     messages: {
-                        "collection_compound\x5Btitle\x5D": {
+                        "collection_compound_form\x5Btitle\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x208\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x20200\x20characters\x20or\x20less."
@@ -327,9 +328,9 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"collection_compound\"]");
+                var form = $("form[name=\"collection_compound_form\"]");
                 var validator = form.validate();
-                form.find("*[name=\"collection_compound\x5Btags\x5D\x5B__name__\x5D\x5Bname\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_compound_form\x5Btags\x5D\x5B__name__\x5D\x5Bname\x5D\"]").rules("add", {
                     "required": true,
                     "minlength": 2,
                     "messages": {
@@ -337,15 +338,15 @@ class BasicFormTest extends FormTestCase
                         "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x202\x20characters\x20or\x20more."
                     }
                 });
-                form.find("*[name=\"collection_compound\x5Btags\x5D\x5B__name__\x5D\x5Bpassword\x5D\x5Bfirst\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_compound_form\x5Btags\x5D\x5B__name__\x5D\x5Bpassword\x5D\x5Bfirst\x5D\"]").rules("add", {
                     "required": true,
                     "messages": {"required": "This\x20value\x20should\x20not\x20be\x20blank."}
                 });
-                form.find("*[name=\"collection_compound\x5Btags\x5D\x5B__name__\x5D\x5Bpassword\x5D\x5Bsecond\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_compound_form\x5Btags\x5D\x5B__name__\x5D\x5Bpassword\x5D\x5Bsecond\x5D\"]").rules("add", {
                     "equalTo": {
-                        param: "form[name=\"collection_compound\"] *[name=\"collection_compound[tags][__name__][password][first]\"]",
+                        param: "form[name=\"collection_compound_form\"] *[name=\"collection_compound_form[tags][__name__][password][first]\"]",
                         depends: function () {
-                            if (("collection_compound\x5Btags\x5D\x5B__name__\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.errorMap || "collection_compound\x5Btags\x5D\x5B__name__\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.invalid)) {
+                            if (("collection_compound_form\x5Btags\x5D\x5B__name__\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.errorMap || "collection_compound_form\x5Btags\x5D\x5B__name__\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
@@ -370,13 +371,13 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"collection_date_time\"]");
+                var form = $("form[name=\"collection_date_time_form\"]");
                 var validator = form.validate({rules: {}, messages: {}});
                 validator.settings.validation_groups = {"Default": false, "main": false};
-                form.find("*[name=\"collection_date_time\x5BdefaultValidation\x5D\"]").click(function () {
+                form.find("*[name=\"collection_date_time_form\x5BdefaultValidation\x5D\"]").click(function () {
                     validator.settings.validation_groups = {"Default": true, "main": false};
                 });
-                form.find("*[name=\"collection_date_time\x5BmainValidation\x5D\"]").click(function () {
+                form.find("*[name=\"collection_date_time_form\x5BmainValidation\x5D\"]").click(function () {
                     validator.settings.validation_groups = {"Default": false, "main": true};
                 });
             })(jQuery);',
@@ -389,9 +390,9 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"collection_date_time\"]");
+                var form = $("form[name=\"collection_date_time_form\"]");
                 var validator = form.validate();
-                form.find("*[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D\"]").rules("add", {
                     "number": true,
                     "required": {
                         depends: function () {
@@ -403,11 +404,11 @@ class BasicFormTest extends FormTestCase
                         "required": "This\x20value\x20should\x20not\x20be\x20blank."
                     }
                 });
-                form.find("*[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D\"]").rules("add", {
                     "required": {
                         depends: function () {
-                            var dep = form.find("[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D\"]")[0];
-                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
+                            var dep = form.find("[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D\"]")[0];
+                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
@@ -415,7 +416,7 @@ class BasicFormTest extends FormTestCase
                     },
                     "min": {
                         param: 1, depends: function () {
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
@@ -423,7 +424,7 @@ class BasicFormTest extends FormTestCase
                     },
                     "max": {
                         param: 12, depends: function () {
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
@@ -435,15 +436,15 @@ class BasicFormTest extends FormTestCase
                         "max": "This\x20value\x20is\x20not\x20valid."
                     }
                 });
-                form.find("*[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D\"]").rules("add", {
                     "required": {
                         depends: function () {
-                            var dep = form.find("[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D\"]")[0];
-                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
+                            var dep = form.find("[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D\"]")[0];
+                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
                                 return false;
                             }
-                            var dep = form.find("[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D\"]")[0];
-                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.invalid)) {
+                            var dep = form.find("[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D\"]")[0];
+                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
@@ -451,10 +452,10 @@ class BasicFormTest extends FormTestCase
                     },
                     "min": {
                         param: 1, depends: function () {
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
                                 return false;
                             }
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
@@ -462,10 +463,10 @@ class BasicFormTest extends FormTestCase
                     },
                     "max": {
                         param: 31, depends: function () {
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
                                 return false;
                             }
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
@@ -477,7 +478,7 @@ class BasicFormTest extends FormTestCase
                         "max": "This\x20value\x20is\x20not\x20valid."
                     }
                 });
-                form.find("*[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D\"]").rules("add", {
                     "min": 0,
                     "max": 23,
                     "required": {
@@ -485,16 +486,16 @@ class BasicFormTest extends FormTestCase
                             if (!(validator.settings.validation_groups["Default"])) {
                                 return false;
                             }
-                            var dep = form.find("[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D\"]")[0];
-                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
+                            var dep = form.find("[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D\"]")[0];
+                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
                                 return false;
                             }
-                            var dep = form.find("[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D\"]")[0];
-                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.invalid)) {
+                            var dep = form.find("[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D\"]")[0];
+                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.invalid)) {
                                 return false;
                             }
-                            var dep = form.find("[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D\"]")[0];
-                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D" in validator.invalid)) {
+                            var dep = form.find("[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D\"]")[0];
+                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
@@ -506,23 +507,23 @@ class BasicFormTest extends FormTestCase
                         "required": "This\x20value\x20is\x20not\x20valid."
                     }
                 });
-                form.find("*[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bminute\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bminute\x5D\"]").rules("add", {
                     "required": {
                         depends: function () {
-                            var dep = form.find("[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D\"]")[0];
-                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
+                            var dep = form.find("[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D\"]")[0];
+                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
                                 return false;
                             }
-                            var dep = form.find("[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D\"]")[0];
-                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.invalid)) {
+                            var dep = form.find("[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D\"]")[0];
+                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.invalid)) {
                                 return false;
                             }
-                            var dep = form.find("[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D\"]")[0];
-                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D" in validator.invalid)) {
+                            var dep = form.find("[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D\"]")[0];
+                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D" in validator.invalid)) {
                                 return false;
                             }
-                            var dep = form.find("[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D\"]")[0];
-                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.invalid)) {
+                            var dep = form.find("[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D\"]")[0];
+                            if ((!$.validator.methods.required.call(validator, validator.elementValue(dep), dep, true) || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
@@ -530,7 +531,7 @@ class BasicFormTest extends FormTestCase
                     },
                     "min": {
                         param: 0, depends: function () {
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
@@ -538,7 +539,7 @@ class BasicFormTest extends FormTestCase
                     },
                     "max": {
                         param: 59, depends: function () {
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
@@ -567,28 +568,28 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"root_form\"]");
+                var form = $("form[name=\"root_data_form\"]");
                 var validator = form.validate({
                     rules: {
-                        "root_form\x5Broot\x5D": {"email": true},
-                        "root_form\x5Bchild\x5D\x5Bname\x5D": {"required": true, "minlength": "2", "maxlength": "255"},
-                        "root_form\x5Bchild\x5D\x5Bpassword\x5D\x5Bfirst\x5D": {"required": true, "minlength": "2", "maxlength": "255"},
-                        "root_form\x5Bchild\x5D\x5Bpassword\x5D\x5Bsecond\x5D": {
+                        "root_data_form\x5Broot\x5D": {"email": true},
+                        "root_data_form\x5Bchild\x5D\x5Bname\x5D": {"required": true, "minlength": "2", "maxlength": "255"},
+                        "root_data_form\x5Bchild\x5D\x5Bpassword\x5D\x5Bfirst\x5D": {"required": true, "minlength": "2", "maxlength": "255"},
+                        "root_data_form\x5Bchild\x5D\x5Bpassword\x5D\x5Bsecond\x5D": {
                             "equalTo": {
-                                param: "form[name=\"root_form\"] *[name=\"root_form[child][password][first]\"]",
+                                param: "form[name=\"root_data_form\"] *[name=\"root_data_form[child][password][first]\"]",
                                 depends: function () {
-                                    if (("root_form\x5Bchild\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.errorMap || "root_form\x5Bchild\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.invalid)) {
+                                    if (("root_data_form\x5Bchild\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.errorMap || "root_data_form\x5Bchild\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.invalid)) {
                                         return false;
                                     }
                                     return true;
                                 }
                             }
                         },
-                        "root_form\x5BchildNoValidation\x5D\x5Bpassword\x5D\x5Bsecond\x5D": {
+                        "root_data_form\x5BchildNoValidation\x5D\x5Bpassword\x5D\x5Bsecond\x5D": {
                             "equalTo": {
-                                param: "form[name=\"root_form\"] *[name=\"root_form[childNoValidation][password][first]\"]",
+                                param: "form[name=\"root_data_form\"] *[name=\"root_data_form[childNoValidation][password][first]\"]",
                                 depends: function () {
-                                    if (("root_form\x5BchildNoValidation\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.errorMap || "root_form\x5BchildNoValidation\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.invalid)) {
+                                    if (("root_data_form\x5BchildNoValidation\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.errorMap || "root_data_form\x5BchildNoValidation\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.invalid)) {
                                         return false;
                                     }
                                     return true;
@@ -597,19 +598,19 @@ class BasicFormTest extends FormTestCase
                         }
                     },
                     messages: {
-                        "root_form\x5Broot\x5D": {"email": "This\x20value\x20is\x20not\x20a\x20valid\x20email\x20address."},
-                        "root_form\x5Bchild\x5D\x5Bname\x5D": {
+                        "root_data_form\x5Broot\x5D": {"email": "This\x20value\x20is\x20not\x20a\x20valid\x20email\x20address."},
+                        "root_data_form\x5Bchild\x5D\x5Bname\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x202\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x20255\x20characters\x20or\x20less."
                         },
-                        "root_form\x5Bchild\x5D\x5Bpassword\x5D\x5Bfirst\x5D": {
+                        "root_data_form\x5Bchild\x5D\x5Bpassword\x5D\x5Bfirst\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x202\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x20255\x20characters\x20or\x20less."
                         },
-                        "root_form\x5Bchild\x5D\x5Bpassword\x5D\x5Bsecond\x5D": {"equalTo": "This\x20value\x20is\x20not\x20valid."},
-                        "root_form\x5BchildNoValidation\x5D\x5Bpassword\x5D\x5Bsecond\x5D": {"equalTo": "This\x20value\x20is\x20not\x20valid."}
+                        "root_data_form\x5Bchild\x5D\x5Bpassword\x5D\x5Bsecond\x5D": {"equalTo": "This\x20value\x20is\x20not\x20valid."},
+                        "root_data_form\x5BchildNoValidation\x5D\x5Bpassword\x5D\x5Bsecond\x5D": {"equalTo": "This\x20value\x20is\x20not\x20valid."}
                     }
                 });
             })(jQuery);',
@@ -630,24 +631,24 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"include_simple_form_data\"]");
+                var form = $("form[name=\"include_simple_form\"]");
                 var validator = form.validate({
                     rules: {
-                        "include_simple_form_data\x5Buser\x5D\x5Bname\x5D": {
+                        "include_simple_form\x5Buser\x5D\x5Bname\x5D": {
                             "required": true,
                             "minlength": "2",
                             "maxlength": "255"
                         },
-                        "include_simple_form_data\x5Buser\x5D\x5Bpassword\x5D\x5Bfirst\x5D": {
+                        "include_simple_form\x5Buser\x5D\x5Bpassword\x5D\x5Bfirst\x5D": {
                             "required": true,
                             "minlength": "2",
                             "maxlength": "255"
                         },
-                        "include_simple_form_data\x5Buser\x5D\x5Bpassword\x5D\x5Bsecond\x5D": {
+                        "include_simple_form\x5Buser\x5D\x5Bpassword\x5D\x5Bsecond\x5D": {
                             "equalTo": {
-                                param: "form[name=\"include_simple_form_data\"] *[name=\"include_simple_form_data[user][password][first]\"]",
+                                param: "form[name=\"include_simple_form\"] *[name=\"include_simple_form[user][password][first]\"]",
                                 depends: function () {
-                                    if (("include_simple_form_data\x5Buser\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.errorMap || "include_simple_form_data\x5Buser\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.invalid)) {
+                                    if (("include_simple_form\x5Buser\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.errorMap || "include_simple_form\x5Buser\x5D\x5Bpassword\x5D\x5Bfirst\x5D" in validator.invalid)) {
                                         return false;
                                     }
                                     return true;
@@ -656,17 +657,17 @@ class BasicFormTest extends FormTestCase
                         }
                     },
                     messages: {
-                        "include_simple_form_data\x5Buser\x5D\x5Bname\x5D": {
+                        "include_simple_form\x5Buser\x5D\x5Bname\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x202\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x20255\x20characters\x20or\x20less."
                         },
-                        "include_simple_form_data\x5Buser\x5D\x5Bpassword\x5D\x5Bfirst\x5D": {
+                        "include_simple_form\x5Buser\x5D\x5Bpassword\x5D\x5Bfirst\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x202\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x20255\x20characters\x20or\x20less."
                         },
-                        "include_simple_form_data\x5Buser\x5D\x5Bpassword\x5D\x5Bsecond\x5D": {"equalTo": "This\x20value\x20is\x20not\x20valid."}
+                        "include_simple_form\x5Buser\x5D\x5Bpassword\x5D\x5Bsecond\x5D": {"equalTo": "This\x20value\x20is\x20not\x20valid."}
                     }
                 });
             })(jQuery);',
@@ -1178,7 +1179,7 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs('
             (function ($) {
                 "use strict";
-                var form = $("form[name=\"additional_rules\"]");
+                var form = $("form[name=\"additional_rules_form\"]");
                 var validator = form.validate({ rules: {}, messages: {}});
             })(jQuery);',
             $javascript
@@ -1197,10 +1198,10 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs('
             (function ($) {
                 "use strict";
-                var form = $("form[name=\"manualGroups\"]");
+                var form = $("form[name=\"manual_groups_form\"]");
                 var validator = form.validate({
                     rules: {
-                        "manualGroups\x5Bname\x5D": {
+                        "manual_groups_form\x5Bname\x5D": {
                             "required": {
                                 depends: function () {
                                     return (validator.settings.validation_groups["Default"]);
@@ -1216,7 +1217,7 @@ class BasicFormTest extends FormTestCase
                             }
                         }
                     }, messages: {
-                        "manualGroups\x5Bname\x5D": {
+                        "manual_groups_form\x5Bname\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x202\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x2010\x20characters\x20or\x20less."
@@ -1241,27 +1242,27 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"recourses\"]");
+                var form = $("form[name=\"recourse\"]");
                 var validator = form.validate({
                     rules: {
-                        "recourses\x5Bcontents\x5D\x5B0\x5D\x5Bmessage\x5D": {
+                        "recourse\x5Bcontents\x5D\x5B0\x5D\x5Bmessage\x5D": {
                             "required": true,
                             "minlength": 3,
                             "maxlength": 8196
                         },
-                        "recourses\x5Bcontents\x5D\x5B1\x5D\x5Bmessage\x5D": {
+                        "recourse\x5Bcontents\x5D\x5B1\x5D\x5Bmessage\x5D": {
                             "required": true,
                             "minlength": 3,
                             "maxlength": 8196
                         }
                     },
                     messages: {
-                        "recourses\x5Bcontents\x5D\x5B0\x5D\x5Bmessage\x5D": {
+                        "recourse\x5Bcontents\x5D\x5B0\x5D\x5Bmessage\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x203\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x208196\x20characters\x20or\x20less."
                         },
-                        "recourses\x5Bcontents\x5D\x5B1\x5D\x5Bmessage\x5D": {
+                        "recourse\x5Bcontents\x5D\x5B1\x5D\x5Bmessage\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x203\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x208196\x20characters\x20or\x20less."
@@ -1316,27 +1317,27 @@ class BasicFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"issue16_collection\"]");
+                var form = $("form[name=\"entity_ref_collection\"]");
                 var validator = form.validate({
                     rules: {
-                        "issue16_collection\x5Brooot\x5D": {
+                        "entity_ref_collection\x5Brooot\x5D": {
                             "required": true,
                             "minlength": "2",
                             "maxlength": "255"
                         },
-                        "issue16_collection\x5BentityReferences\x5D\x5B0\x5D\x5Breference\x5D": {
+                        "entity_ref_collection\x5BentityReferences\x5D\x5B0\x5D\x5Breference\x5D": {
                             "required": true,
                             "minlength": "2",
                             "maxlength": "255"
                         }
                     },
                     messages: {
-                        "issue16_collection\x5Brooot\x5D": {
+                        "entity_ref_collection\x5Brooot\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x202\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x20255\x20characters\x20or\x20less."
                         },
-                        "issue16_collection\x5BentityReferences\x5D\x5B0\x5D\x5Breference\x5D": {
+                        "entity_ref_collection\x5BentityReferences\x5D\x5B0\x5D\x5Breference\x5D": {
                             "required": "This\x20value\x20should\x20not\x20be\x20blank.",
                             "minlength": "This\x20value\x20is\x20too\x20short.\x20It\x20should\x20have\x202\x20characters\x20or\x20more.",
                             "maxlength": "This\x20value\x20is\x20too\x20long.\x20It\x20should\x20have\x20255\x20characters\x20or\x20less."

--- a/tests/Functional/TestBundle/Controller/FormController.php
+++ b/tests/Functional/TestBundle/Controller/FormController.php
@@ -1,26 +1,15 @@
 <?php
 namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Controller;
 
+use Boekkooi\Bundle\JqueryValidationBundle\Form\Util\FormHelper;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Util\FormUtil;
 use Symfony\Component\HttpFoundation\Request;
-use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\AdditionalRulesFormType;
-use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\ButtonsFormType;
-use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\CollectionCompoundFormType;
-use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\CollectionDateTimeFormType;
-use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\CollectionFormType;
-use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\CollectionWithGroupsFormType;
-use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\DateTimeFormType;
-use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\IsTrueOrFalseFormType;
-use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\ManualGroupsFormType;
-use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\RootDataFormType;
-use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\SimpleDataFormType;
-use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\SimpleFormType;
-use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\IncludeSimpleFormType;
-use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\ViewTransformRulesFormType;
 use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Issue7;
 use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Issue8;
 use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Issue16;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Issue20;
 
 /**
@@ -30,7 +19,7 @@ class FormController extends Controller
 {
     public function simpleAction(Request $request)
     {
-        $form = $this->createForm(new SimpleFormType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\SimpleFormType');
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView()));
@@ -38,7 +27,9 @@ class FormController extends Controller
 
     public function simpleDataAction(Request $request)
     {
-        $form = $this->createForm(new SimpleDataFormType());
+        $form = $this->createForm(
+            'Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\SimpleDataFormType'
+        );
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView()));
@@ -46,7 +37,7 @@ class FormController extends Controller
 
     public function dateTimeAction(Request $request)
     {
-        $form = $this->createForm(new DateTimeFormType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\DateTimeFormType');
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView()));
@@ -54,7 +45,7 @@ class FormController extends Controller
 
     public function includeSimpleDataAction(Request $request)
     {
-        $form = $this->createForm(new IncludeSimpleFormType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\IncludeSimpleFormType');
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView()));
@@ -62,7 +53,7 @@ class FormController extends Controller
 
     public function buttonsAction(Request $request)
     {
-        $form = $this->createForm(new ButtonsFormType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\ButtonsFormType');
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView(), 'button' => true));
@@ -70,7 +61,7 @@ class FormController extends Controller
 
     public function collectionAction(Request $request)
     {
-        $form = $this->createForm(new CollectionFormType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\CollectionFormType');
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView()));
@@ -78,7 +69,7 @@ class FormController extends Controller
 
     public function collectionWithGroupAction(Request $request)
     {
-        $form = $this->createForm(new CollectionWithGroupsFormType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\CollectionWithGroupsFormType');
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView(), 'button' => true));
@@ -86,7 +77,7 @@ class FormController extends Controller
 
     public function collectionCompoundAction(Request $request)
     {
-        $form = $this->createForm(new CollectionCompoundFormType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\CollectionCompoundFormType');
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView()));
@@ -94,7 +85,7 @@ class FormController extends Controller
 
     public function childDataAction(Request $request)
     {
-        $form = $this->createForm(new RootDataFormType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\RootDataFormType');
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView()));
@@ -102,7 +93,7 @@ class FormController extends Controller
 
     public function viewTransformAction(Request $request)
     {
-        $form = $this->createForm(new ViewTransformRulesFormType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\ViewTransformRulesFormType');
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView(), 'button' => true));
@@ -110,7 +101,7 @@ class FormController extends Controller
 
     public function collectionDateTimeAction(Request $request)
     {
-        $form = $this->createForm(new CollectionDateTimeFormType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\CollectionDateTimeFormType');
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView(), 'button' => true));
@@ -118,7 +109,7 @@ class FormController extends Controller
 
     public function additionalRulesAction(Request $request)
     {
-        $form = $this->createForm(new AdditionalRulesFormType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\AdditionalRulesFormType');
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView()));
@@ -126,7 +117,7 @@ class FormController extends Controller
 
     public function manualGroupsAction(Request $request)
     {
-        $form = $this->createForm(new ManualGroupsFormType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\ManualGroupsFormType');
         $this->handleForm($request, $form);
 
         return $this->render('::form_manual_groups.html.twig', array('form' => $form->createView()));
@@ -134,7 +125,7 @@ class FormController extends Controller
 
     public function isTrueOrFalseAction(Request $request)
     {
-        $form = $this->createForm(new IsTrueOrFalseFormType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\IsTrueOrFalseFormType');
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView()));
@@ -151,7 +142,7 @@ class FormController extends Controller
             new Issue7\Model\Content()
         ));
 
-        $form = $this->createForm(new Issue7\Type\RecourseType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Issue7\Type\RecourseType');
         $form->setData($resource);
         $this->handleForm($request, $form);
 
@@ -162,7 +153,7 @@ class FormController extends Controller
     {
         $resource = new Issue8\Model\TestRangeEntity();
 
-        $form = $this->createForm(new Issue8\Type\TestRangeType());
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Issue8\Type\TestRangeType');
         $form->setData($resource);
         $this->handleForm($request, $form);
 
@@ -174,7 +165,7 @@ class FormController extends Controller
         $collection = new Issue16\Model\EntityRefCollection();
         $collection->entityReferences[] = new Issue16\Model\EntityReferenceModel();
 
-        $form = $this->createForm(new Issue16\Type\EntityRefCollectionType(), $collection);
+        $form = $this->createForm('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Issue16\Type\EntityRefCollectionType', $collection);
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView()));
@@ -183,7 +174,7 @@ class FormController extends Controller
     public function issue17EmptyNameAction(Request $request)
     {
         /** @var FormInterface $form */
-        $form = $this->get('form.factory')->createNamed('', new SimpleFormType());
+        $form = $this->get('form.factory')->createNamed('', TypeHelper::type('Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type\SimpleFormType'));
         $this->handleForm($request, $form);
 
         return $this->render('::form.html.twig', array('form' => $form->createView()));
@@ -203,7 +194,7 @@ class FormController extends Controller
     public function issue20Action(Request $request)
     {
         $form = $this->createForm(
-            new Issue20\Form\Type\ScheduleFormType(),
+            'Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Issue20\Form\Type\ScheduleFormType',
             new Issue20\Model\Schedule()
         );
         $this->handleForm($request, $form);
@@ -219,6 +210,11 @@ class FormController extends Controller
         } elseif ($request->isMethod('POST')) {
             $this->addNotice(date('H:i:s').': Invalid');
         }
+    }
+
+    public function createForm($type, $data = null, array $options = array())
+    {
+        return parent::createForm(TypeHelper::type($type), $data, $options);
     }
 
     private function addNotice($message)

--- a/tests/Functional/TestBundle/Form/Issue16/Type/EmailType.php
+++ b/tests/Functional/TestBundle/Form/Issue16/Type/EmailType.php
@@ -3,7 +3,9 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Laurent Heurtault <l.heurtault@lexik.fr>
@@ -17,7 +19,7 @@ class EmailType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('reference', null, array(
+            ->add('reference', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\TextType'), array(
                 'property_path' => 'entity.name',
                 'label'         => 'Entity.name',
             ))
@@ -29,16 +31,26 @@ class EmailType extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver->setDefaults(array(
-            'data_class' => 'Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Issue16\Model\EntityReferenceModel'
-        ));
+        $this->configureOptions($resolver);
     }
 
     /**
      * {@inheritdoc}
      */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => 'Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Issue16\Model\EntityReferenceModel'
+        ));
+    }
+
     public function getName()
     {
-        return 'issue16_type';
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'entity_ref_email';
     }
 }

--- a/tests/Functional/TestBundle/Form/Issue16/Type/EntityRefCollectionType.php
+++ b/tests/Functional/TestBundle/Form/Issue16/Type/EntityRefCollectionType.php
@@ -3,6 +3,10 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Issue16\Model\EntityRefCollection;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -16,14 +20,16 @@ class EntityRefCollectionType extends AbstractType
                 'property_path' => 'root[0].child.name',
                 'label'         => 'Root[0].child.name',
             ))
-            ->add('entityReferences', 'collection', array(
-                'type' => new EmailType(),
+            ->add('entityReferences', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\CollectionType'),
+                TypeHelper::fixCollectionOptions(array(
+                    'entry_type' => __NAMESPACE__ . '\EmailType',
 
-                'allow_add' => true,
-                'allow_delete' => true,
+                    'allow_add' => true,
+                    'allow_delete' => true,
 
-                'prototype' => true
-            ))
+                    'prototype' => true
+                ))
+            )
         ;
     }
 
@@ -32,6 +38,6 @@ class EntityRefCollectionType extends AbstractType
      */
     public function getName()
     {
-        return 'issue16_collection';
+        return 'entity_ref_collection';
     }
 }

--- a/tests/Functional/TestBundle/Form/Issue7/Type/ContentType.php
+++ b/tests/Functional/TestBundle/Form/Issue7/Type/ContentType.php
@@ -3,7 +3,9 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -12,21 +14,25 @@ class ContentType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('message', 'textarea', array(
+        $builder->add('message', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\TextareaType'), array(
             'attr' => array('placeholder' => 'Ваше сообщение')
         ));
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
         $resolver->setDefaults(array(
             'data_class' => 'Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Issue7\Model\Content'
         ));
     }
 
-
     public function getName()
     {
-        return 'contents';
+        return 'content';
     }
 }

--- a/tests/Functional/TestBundle/Form/Issue7/Type/RecourseType.php
+++ b/tests/Functional/TestBundle/Form/Issue7/Type/RecourseType.php
@@ -3,7 +3,10 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Validator\Constraints\Valid;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -12,20 +15,34 @@ class RecourseType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('contents', 'collection', array(
-            'type' => new ContentType,
-            'options' => array('label' => false),
-            'cascade_validation' => true,
-            'label' => false,
-        ));
-        $builder->add('invalidContents', 'collection', array(
-            'type' => new ContentType,
-            'options' => array('label' => false),
-            'label' => false,
-        ));
+        $builder->add('contents',
+            TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\CollectionType'),
+            TypeHelper::fixCollectionOptions(array(
+                'entry_type' => 'Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Issue7\Type\ContentType',
+                'entry_options' => array('label' => false),
+                'constraints' => array(
+                    new Valid()
+                ),
+                'label' => false,
+            ))
+        );
+        $builder->add(
+            'invalidContents',
+            TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\CollectionType'),
+            TypeHelper::fixCollectionOptions(array(
+                'entry_type' => 'Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Issue7\Type\ContentType',
+                'entry_options' => array('label' => false),
+                'label' => false,
+            ))
+        );
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Issue7\Model\Recourse'
@@ -34,7 +51,6 @@ class RecourseType extends AbstractType
 
     public function getName()
     {
-        return 'recourses';
+        return 'recourse';
     }
-
 }

--- a/tests/Functional/TestBundle/Form/Issue8/Type/RangeType.php
+++ b/tests/Functional/TestBundle/Form/Issue8/Type/RangeType.php
@@ -5,7 +5,9 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -43,8 +45,30 @@ class RangeType extends AbstractType
         ));
     }
 
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'options' => array(),
+            'min_options' => array(),
+            'max_options' => array(),
+            'min_name' => 'min',
+            'max_name' => 'max',
+            'error_bubbling' => false,
+        ));
+
+        $resolver->setAllowedTypes('options', 'array');
+        $resolver->setAllowedTypes('min_options', 'array');
+        $resolver->setAllowedTypes('max_options', 'array');
+    }
+
     public function getName()
     {
-        return 'my_range';
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'issue8_range';
     }
 }

--- a/tests/Functional/TestBundle/Form/Issue8/Type/TestRangeType.php
+++ b/tests/Functional/TestBundle/Form/Issue8/Type/TestRangeType.php
@@ -3,25 +3,30 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
  */
-class TestRangeType  extends AbstractType
+class TestRangeType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('size', new RangeType(), array(
-            'virtual' => true,
+        $builder->add('size', TypeHelper::type(__NAMESPACE__ . '\RangeType'), array(
+            'inherit_data' => true,
             'min_name' => 'min_size',
-            'max_name' => 'max_size'
+            'max_name' => 'max_size',
         ));
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Issue8\Model\TestRangeEntity'

--- a/tests/Functional/TestBundle/Form/Type/AdditionalRulesFormType.php
+++ b/tests/Functional/TestBundle/Form/Type/AdditionalRulesFormType.php
@@ -4,6 +4,7 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -47,7 +48,7 @@ class AdditionalRulesFormType extends AbstractType
                 ),
             ))
 
-            ->add('file', 'file', array(
+            ->add('file', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\FileType'), array(
                 'constraints' => array(
                     new Constraints\File(array(
                         'mimeTypes' => array('text/plain', 'application/pdf'),
@@ -55,7 +56,7 @@ class AdditionalRulesFormType extends AbstractType
                 ),
             ))
 
-            ->add('pattern', 'text', array(
+            ->add('pattern', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\TextType'), array(
                 'constraints' => array(
                     new Constraints\Regex('/^[a-zA-Z]+$/'),
                 ),
@@ -65,6 +66,6 @@ class AdditionalRulesFormType extends AbstractType
 
     public function getName()
     {
-        return 'additional_rules';
+        return 'additional_rules_form';
     }
 }

--- a/tests/Functional/TestBundle/Form/Type/ButtonsFormType.php
+++ b/tests/Functional/TestBundle/Form/Type/ButtonsFormType.php
@@ -4,6 +4,7 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -23,7 +24,7 @@ class ButtonsFormType extends AbstractType
                     )),
                 ),
             ))
-            ->add('content', 'textarea', array(
+            ->add('content', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\TextareaType'), array(
                 'constraints' => array(
                     new Constraints\NotBlank(),
                     new Constraints\Length(array(
@@ -33,14 +34,14 @@ class ButtonsFormType extends AbstractType
                     )),
                 ),
             ))
-            ->add('defaultValidation', 'submit')
-            ->add('mainValidation', 'submit', array(
+            ->add('defaultValidation', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\SubmitType'))
+            ->add('mainValidation', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\SubmitType'), array(
                 'validation_groups' => 'main',
             ))
-            ->add('mainAndDefaultValidation', 'submit', array(
+            ->add('mainAndDefaultValidation', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\SubmitType'), array(
                 'validation_groups' => array('main', 'Default'),
             ))
-            ->add('noValidation', 'submit', array(
+            ->add('noValidation', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\SubmitType'), array(
                 'validation_groups' => false,
             ))
         ;
@@ -48,6 +49,6 @@ class ButtonsFormType extends AbstractType
 
     public function getName()
     {
-        return 'buttons';
+        return 'buttons_form';
     }
 }

--- a/tests/Functional/TestBundle/Form/Type/CollectionCompoundFormType.php
+++ b/tests/Functional/TestBundle/Form/Type/CollectionCompoundFormType.php
@@ -4,6 +4,7 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -14,24 +15,27 @@ class CollectionCompoundFormType extends AbstractType
     {
         $builder
             ->add('title', null, array(
-                    'constraints' => array(
-                        new Constraints\NotBlank(),
-                        new Constraints\Length(array(
-                            'min' => 8,
-                            'max' => 200,
-                        )),
-                    ),
-                ))
-            ->add('tags', 'collection', array(
-                    'type' => new SimpleFormType(),
+                'constraints' => array(
+                    new Constraints\NotBlank(),
+                    new Constraints\Length(array(
+                        'min' => 8,
+                        'max' => 200,
+                    )),
+                ),
+            ))
+            ->add('tags',
+                TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\CollectionType'),
+                TypeHelper::fixCollectionOptions(array(
+                    'entry_type' => __NAMESPACE__ . '\SimpleFormType',
                     'allow_add' => true,
                     'allow_delete' => true,
                 ))
+            )
         ;
     }
 
     public function getName()
     {
-        return 'collection_compound';
+        return 'collection_compound_form';
     }
 }

--- a/tests/Functional/TestBundle/Form/Type/CollectionDateTimeFormType.php
+++ b/tests/Functional/TestBundle/Form/Type/CollectionDateTimeFormType.php
@@ -4,6 +4,7 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -13,8 +14,9 @@ class CollectionDateTimeFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('tags', 'collection', array(
-                'type' => 'datetime',
+            ->add('tags',
+                TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\CollectionType'),
+                TypeHelper::fixCollectionOptions(array(
                 'constraints' => array(
                     new Constraints\Count(array(
                         'min' => 1,
@@ -26,15 +28,17 @@ class CollectionDateTimeFormType extends AbstractType
                 'allow_delete' => true,
 
                 'prototype' => true,
-                'options' => array(
+
+                'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\DateTimeType',
+                'entry_options' => array(
                     'widget' => 'text',
                     'constraints' => array(
                         new Constraints\NotBlank(),
                     ),
                 ),
-            ))
-            ->add('defaultValidation', 'submit')
-            ->add('mainValidation', 'submit', array(
+            )))
+            ->add('defaultValidation', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\SubmitType'))
+            ->add('mainValidation', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\SubmitType'), array(
                 'validation_groups' => 'main',
             ))
         ;
@@ -42,6 +46,6 @@ class CollectionDateTimeFormType extends AbstractType
 
     public function getName()
     {
-        return 'collection_date_time';
+        return 'collection_date_time_form';
     }
 }

--- a/tests/Functional/TestBundle/Form/Type/CollectionFormType.php
+++ b/tests/Functional/TestBundle/Form/Type/CollectionFormType.php
@@ -4,6 +4,7 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -14,16 +15,17 @@ class CollectionFormType extends AbstractType
     {
         $builder
             ->add('title', null, array(
-                    'constraints' => array(
-                        new Constraints\NotBlank(),
-                        new Constraints\Length(array(
-                            'min' => 8,
-                            'max' => 200,
-                        )),
-                    ),
-                ))
-            ->add('tags', 'collection', array(
-                    'type' => 'text',
+                'constraints' => array(
+                    new Constraints\NotBlank(),
+                    new Constraints\Length(array(
+                        'min' => 8,
+                        'max' => 200,
+                    )),
+                ),
+            ))
+            ->add('tags',
+                TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\CollectionType'),
+                TypeHelper::fixCollectionOptions(array(
                     'constraints' => array(
                         new Constraints\Count(array(
                             'min' => 1,
@@ -36,17 +38,20 @@ class CollectionFormType extends AbstractType
 
                     'prototype' => true,
                     'prototype_name' => 'tag__name__',
-                    'options' => array(
+
+                    'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+                    'entry_options' => array(
                         'constraints' => array(
                             new Constraints\NotBlank(),
                         ),
                     ),
                 ))
+            )
         ;
     }
 
     public function getName()
     {
-        return 'collection';
+        return 'collection_form';
     }
 }

--- a/tests/Functional/TestBundle/Form/Type/CollectionWithGroupsFormType.php
+++ b/tests/Functional/TestBundle/Form/Type/CollectionWithGroupsFormType.php
@@ -2,8 +2,12 @@
 namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -14,6 +18,33 @@ class CollectionWithGroupsFormType extends AbstractType
     {
         $builder
             ->add('title', null, array(
+                'constraints' => array(
+                    new Constraints\NotBlank(),
+                    new Constraints\Length(array(
+                        'min' => 8,
+                        'max' => 200,
+                        'groups' => 'main',
+                    )),
+                ),
+            ))
+            ->add('tags',
+                TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\CollectionType'),
+                TypeHelper::fixCollectionOptions(array(
+                'constraints' => array(
+                    new Constraints\Count(array(
+                        'min' => 1,
+                        'max' => 5,
+                    )),
+                ),
+
+                'allow_add' => true,
+                'allow_delete' => true,
+
+                'prototype' => true,
+                'prototype_name' => 'tag__name__',
+
+                'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+                'entry_options' => array(
                     'constraints' => array(
                         new Constraints\NotBlank(),
                         new Constraints\Length(array(
@@ -22,34 +53,10 @@ class CollectionWithGroupsFormType extends AbstractType
                             'groups' => 'main',
                         )),
                     ),
-                ))
-            ->add('tags', 'collection', array(
-                    'type' => 'text',
-                    'constraints' => array(
-                        new Constraints\Count(array(
-                            'min' => 1,
-                            'max' => 5,
-                        )),
-                    ),
-
-                    'allow_add' => true,
-                    'allow_delete' => true,
-
-                    'prototype' => true,
-                    'prototype_name' => 'tag__name__',
-                    'options' => array(
-                        'constraints' => array(
-                            new Constraints\NotBlank(),
-                            new Constraints\Length(array(
-                                'min' => 8,
-                                'max' => 200,
-                                'groups' => 'main',
-                            )),
-                        ),
-                    ),
-                ))
-            ->add('defaultValidation', 'submit')
-            ->add('mainValidation', 'submit', array(
+                ),
+            )))
+            ->add('defaultValidation', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\SubmitType'))
+            ->add('mainValidation', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\SubmitType'), array(
                 'validation_groups' => 'main',
             ))
         ;
@@ -57,6 +64,6 @@ class CollectionWithGroupsFormType extends AbstractType
 
     public function getName()
     {
-        return 'collection';
+        return 'collection_with_groups_form';
     }
 }

--- a/tests/Functional/TestBundle/Form/Type/DateTimeFormType.php
+++ b/tests/Functional/TestBundle/Form/Type/DateTimeFormType.php
@@ -4,6 +4,7 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -13,7 +14,7 @@ class DateTimeFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('datetime_choice', 'datetime', array(
+            ->add('datetime_choice', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\DateTimeType'), array(
                 'label' => 'DateTime choice',
                 'required' => false,
                 'constraints' => array(
@@ -21,21 +22,21 @@ class DateTimeFormType extends AbstractType
                 ),
             ))
 
-            ->add('date_choice', 'date', array(
+            ->add('date_choice', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\DateType'), array(
                 'label' => 'Date choice',
                 'required' => false,
                 'constraints' => array(
                     new Constraints\NotBlank(),
                 ),
             ))
-            ->add('date_text', 'date', array(
+            ->add('date_text', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\DateType'), array(
                 'widget' => 'text',
                 'label' => 'Date text',
                 'constraints' => array(
                     new Constraints\NotBlank(),
                 ),
             ))
-            ->add('date_single_text', 'date', array(
+            ->add('date_single_text', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\DateType'), array(
                 'widget' => 'single_text',
                 'label' => 'Date single text',
                 'constraints' => array(
@@ -43,7 +44,7 @@ class DateTimeFormType extends AbstractType
                 ),
             ))
 
-            ->add('time_choice', 'time', array(
+            ->add('time_choice', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\TimeType'), array(
                 'widget' => 'choice',
                 'label' => 'Time choice',
                 'required' => false,
@@ -51,14 +52,14 @@ class DateTimeFormType extends AbstractType
                     new Constraints\NotBlank(),
                 ),
             ))
-            ->add('time_text', 'time', array(
+            ->add('time_text', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\TimeType'), array(
                 'widget' => 'text',
                 'label' => 'Time text',
                 'constraints' => array(
                     new Constraints\NotBlank(),
                 ),
             ))
-            ->add('time_single_text', 'time', array(
+            ->add('time_single_text', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\TimeType'), array(
                 'widget' => 'single_text',
                 'label' => 'Time single text',
                 'constraints' => array(
@@ -68,9 +69,6 @@ class DateTimeFormType extends AbstractType
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName()
     {
         return 'date_time_form';

--- a/tests/Functional/TestBundle/Form/Type/IncludeSimpleFormType.php
+++ b/tests/Functional/TestBundle/Form/Type/IncludeSimpleFormType.php
@@ -3,14 +3,16 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 class IncludeSimpleFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('user', new SimpleDataFormType(), array(
+            ->add('user', TypeHelper::type(__NAMESPACE__ . '\SimpleDataFormType'), array(
                 'mapped' => false,
                 'inherit_data' => true,
             ))
@@ -18,6 +20,11 @@ class IncludeSimpleFormType extends AbstractType
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'validation_groups' => array(
@@ -29,6 +36,6 @@ class IncludeSimpleFormType extends AbstractType
 
     public function getName()
     {
-        return 'include_simple_form_data';
+        return 'include_simple_form';
     }
 }

--- a/tests/Functional/TestBundle/Form/Type/IsTrueOrFalseFormType.php
+++ b/tests/Functional/TestBundle/Form/Type/IsTrueOrFalseFormType.php
@@ -1,56 +1,66 @@
 <?php
 namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type;
 
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 class IsTrueOrFalseFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('check-true', 'checkbox', array(
+            ->add('check-true', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\CheckboxType'), array(
                 'label' => 'Checkbox',
                 'constraints' => array(
                     new Constraints\IsTrue()
                 )
             ))
-            ->add('select-bool-true', 'choice', array(
-                'label' => 'Select',
-                'choices' => array(true => 'Yes', false => 'No'),
-                'constraints' => array(
-                    new Constraints\IsTrue()
-                )
-            ))
-            ->add('select-int-true', 'choice', array(
-                'label' => 'Select',
-                'choices' => array('1' => 'Yes', '0' => 'No'),
-                'constraints' => array(
-                    new Constraints\IsTrue()
-                )
-            ))
-            ->add('text-true', 'text', array(
+            ->add('select-bool-true', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\ChoiceType'),
+                TypeHelper::fixChoices(array(
+                    'label' => 'Select',
+                    'choices' => array('Yes' => true, 'No' => false),
+                    'constraints' => array(
+                        new Constraints\IsTrue()
+                    )
+                ))
+            )
+            ->add('select-int-true', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\ChoiceType'),
+                TypeHelper::fixChoices(array(
+                    'label' => 'Select',
+                    'choices' => array('Yes' => '1', 'No' => '0'),
+                    'constraints' => array(
+                        new Constraints\IsTrue()
+                    )
+                ))
+            )
+            ->add('text-true', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\TextType'), array(
                 'label' => 'Text (1 === true)',
                 'constraints' => array(
                     new Constraints\IsTrue()
                 )
             ))
 
-            ->add('check-false', 'checkbox', array(
+            ->add('check-false', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\CheckboxType'), array(
                 'label' => 'Checkbox',
                 'constraints' => array(
                     new Constraints\IsFalse()
                 )
             ))
-            ->add('select-false', 'choice', array(
-                'label' => 'Select',
-                'choices' => array('1' => 'Yes', '0' => 'No'),
-                'constraints' => array(
-                    new Constraints\IsFalse()
-                )
-            ))
-            ->add('text-false', 'text', array(
+            ->add('select-false', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\ChoiceType'),
+                TypeHelper::fixChoices(array(
+                    'label' => 'Select',
+                    'choices' => array('Yes' => '1', 'No' => '0'),
+                    'constraints' => array(
+                        new Constraints\IsFalse()
+                    )
+                ))
+            )
+            ->add('text-false', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\TextType'), array(
                 'label' => 'Text (0 === false)',
                 'constraints' => array(
                     new Constraints\IsFalse()
@@ -64,6 +74,6 @@ class IsTrueOrFalseFormType extends AbstractType
      */
     public function getName()
     {
-        return 'isTrueOrFalse';
+        return 'is_true_or_false_form';
     }
 }

--- a/tests/Functional/TestBundle/Form/Type/ManualGroupsFormType.php
+++ b/tests/Functional/TestBundle/Form/Type/ManualGroupsFormType.php
@@ -1,18 +1,20 @@
 <?php
 namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Type;
 
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 class ManualGroupsFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('name', 'text', array(
+            ->add('name', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\TextType'), array(
                 'label' => 'Name',
                 'constraints' => array(
                     new Constraints\NotBlank(),
@@ -23,13 +25,18 @@ class ManualGroupsFormType extends AbstractType
                     )),
                 )
             ))
-            ->add('lengthCheck', 'checkbox', array(
+            ->add('lengthCheck', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\CheckboxType'), array(
                 'label' => 'Enable length validation group',
             ))
         ;
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Model\ManualGroupsData',
@@ -45,6 +52,6 @@ class ManualGroupsFormType extends AbstractType
      */
     public function getName()
     {
-        return 'manualGroups';
+        return 'manual_groups_form';
     }
 }

--- a/tests/Functional/TestBundle/Form/Type/RootDataFormType.php
+++ b/tests/Functional/TestBundle/Form/Type/RootDataFormType.php
@@ -3,7 +3,9 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -13,13 +15,18 @@ class RootDataFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('root', 'text', array('label' => 'Root Name'))
-            ->add('child', new SimpleDataFormType())
-            ->add('childNoValidation', new SimpleDataFormType())
+            ->add('root', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\TextType'), array('label' => 'Root Name'))
+            ->add('child', TypeHelper::type(__NAMESPACE__ . '\SimpleDataFormType'))
+            ->add('childNoValidation', TypeHelper::type(__NAMESPACE__ . '\SimpleDataFormType'))
         ;
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Model\RootData',
@@ -31,6 +38,6 @@ class RootDataFormType extends AbstractType
      */
     public function getName()
     {
-        return 'root_form';
+        return 'root_data_form';
     }
 }

--- a/tests/Functional/TestBundle/Form/Type/SimpleDataFormType.php
+++ b/tests/Functional/TestBundle/Form/Type/SimpleDataFormType.php
@@ -3,7 +3,9 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -13,12 +15,21 @@ class SimpleDataFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('name', 'text', array('label' => 'Name'))
-            ->add('password', 'repeated', array('type' => 'password'))
+            ->add('name', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\TextType'), array('label' => 'Name'))
+            ->add(
+                'password',
+                TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\RepeatedType'),
+                array('type' => TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\PasswordType'))
+            )
         ;
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\Model\SimpleData',
@@ -30,6 +41,6 @@ class SimpleDataFormType extends AbstractType
      */
     public function getName()
     {
-        return 'simple_form_data';
+        return 'simple_data_form';
     }
 }

--- a/tests/Functional/TestBundle/Form/Type/SimpleFormType.php
+++ b/tests/Functional/TestBundle/Form/Type/SimpleFormType.php
@@ -4,6 +4,7 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -13,15 +14,15 @@ class SimpleFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('name', 'text', array(
+            ->add('name', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\TextType'), array(
                 'label' => 'Name',
                 'constraints' => array(
                     new Constraints\NotBlank(),
                     new Constraints\Length(array('min' => 2)),
                 ),
             ))
-            ->add('password', 'repeated', array(
-                'type' => 'password',
+            ->add('password', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\RepeatedType'), array(
+                'type' => TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\PasswordType'),
                 'constraints' => array(
                     new Constraints\NotBlank(),
                 ),

--- a/tests/Functional/TestBundle/Form/Type/ViewTransformRulesFormType.php
+++ b/tests/Functional/TestBundle/Form/Type/ViewTransformRulesFormType.php
@@ -4,6 +4,7 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\For
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 
 /**
  * @author Warnar Boekkooi <warnar@boekkooi.net>
@@ -13,15 +14,14 @@ class ViewTransformRulesFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('time_text', 'time', array(
+            ->add('time_text', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\TimeType'), array(
                 'widget' => 'text',
                 'label' => 'Time text',
                 'constraints' => array(
                     new Constraints\NotBlank(),
                 ),
             ))
-            ->add('equals', 'repeated', array(
-                'type' => 'text',
+            ->add('equals', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\RepeatedType'), array(
                 'constraints' => array(
                     new Constraints\NotBlank(array(
                         'groups' => 'main',
@@ -31,16 +31,13 @@ class ViewTransformRulesFormType extends AbstractType
                 'second_options' => array('label' => 'Repeat'),
                 'invalid_message' => 'Oops they don\'t match',
             ))
-            ->add('defaultValidation', 'submit')
-            ->add('mainValidation', 'submit', array(
+            ->add('defaultValidation', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\SubmitType'))
+            ->add('mainValidation', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\SubmitType'), array(
                 'validation_groups' => 'main',
             ))
         ;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName()
     {
         return 'view_transform_rules_form';

--- a/tests/Functional/TestBundle/Form/TypeHelper.php
+++ b/tests/Functional/TestBundle/Form/TypeHelper.php
@@ -1,0 +1,56 @@
+<?php
+namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form;
+
+use Boekkooi\Bundle\JqueryValidationBundle\Form\Util\FormHelper;
+
+class TypeHelper
+{
+    public static function type($fqcn)
+    {
+        if (!FormHelper::isSymfony3Compatible() && is_string($fqcn)) {
+            if (strpos($fqcn, 'Symfony\Component\Form\Extension\Core\Type\\') === 0) {
+                return strtolower(substr($fqcn, 43, -4));
+            }
+
+            return new $fqcn();
+        }
+
+        return $fqcn;
+    }
+
+    public static function fixCollectionOptions(array $options)
+    {
+        if (FormHelper::isSymfony3Compatible()) {
+            return $options;
+        }
+
+        if (isset($options['entry_type'])) {
+            $options['type'] = TypeHelper::type($options['entry_type']);
+            unset($options['entry_type']);
+        }
+
+        if (isset($options['entry_options'])) {
+            $options['options'] = TypeHelper::type($options['entry_options']);
+            unset($options['entry_options']);
+        }
+
+        return $options;
+    }
+
+    public static function fixChoices(array $options)
+    {
+        if (!method_exists('Symfony\Component\Form\ResolvedFormTypeInterface', 'getName')) {
+            return $options;
+        }
+
+        if (isset($options['choices'])) {
+            $choices = array();
+            foreach ($options['choices'] as $k => $v) {
+                $choices[$v] = $k;
+            }
+            $options['choices'] = $choices;
+        }
+
+        return $options;
+    }
+}

--- a/tests/Functional/TestBundle/Issue20/Form/Type/ScheduleFormType.php
+++ b/tests/Functional/TestBundle/Issue20/Form/Type/ScheduleFormType.php
@@ -3,7 +3,9 @@ namespace Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Iss
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Form\TypeHelper;
 use Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Issue20\Constraints\ValidScheduledEndDate;
 
 class ScheduleFormType extends AbstractType
@@ -11,17 +13,22 @@ class ScheduleFormType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('isScheduledEndDate', 'checkbox', array(
+            ->add('isScheduledEndDate', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\CheckboxType'), array(
                 'label'    => 'Is there a end date?',
                 'required' => false,
             ))
-            ->add('scheduledEndDate', 'datetime', array(
+            ->add('scheduledEndDate', TypeHelper::type('Symfony\Component\Form\Extension\Core\Type\DateTimeType'), array(
                 'label' => 'Scheduled end date',
                 'required' => false,
             ));
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'data_class' => 'Tests\Boekkooi\Bundle\JqueryValidationBundle\Functional\TestBundle\Issue20\Model\Schedule',
@@ -39,6 +46,6 @@ class ScheduleFormType extends AbstractType
      */
     public function getName()
     {
-        return str_replace('\\', '_', __CLASS__);
+        return 'schedule_form';
     }
 }

--- a/tests/Functional/TotalFormTest.php
+++ b/tests/Functional/TotalFormTest.php
@@ -27,13 +27,13 @@ class TotalFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"collection_date_time\"]");
+                var form = $("form[name=\"collection_date_time_form\"]");
                 var validator = form.validate({rules: {}, messages: {}});
                 validator.settings.validation_groups = {"Default": false, "main": false};
-                form.find("*[name=\"collection_date_time\x5BdefaultValidation\x5D\"]").click(function () {
+                form.find("*[name=\"collection_date_time_form\x5BdefaultValidation\x5D\"]").click(function () {
                     validator.settings.validation_groups = {"Default": true, "main": false};
                 });
-                form.find("*[name=\"collection_date_time\x5BmainValidation\x5D\"]").click(function () {
+                form.find("*[name=\"collection_date_time_form\x5BmainValidation\x5D\"]").click(function () {
                     validator.settings.validation_groups = {"Default": false, "main": true};
                 });
             })(jQuery);',
@@ -46,11 +46,11 @@ class TotalFormTest extends FormTestCase
         $this->assertEqualJs(
             '(function ($) {
                 "use strict";
-                var form = $("form[name=\"collection_date_time\"]");
+                var form = $("form[name=\"collection_date_time_form\"]");
                 var validator = form.validate();
-                form.find("*[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D\"]").rules("add", {
                     "number": true,
-                    "required_group": ["collection_date_time[tags][__name__][date][month]", "collection_date_time[tags][__name__][date][day]", "collection_date_time[tags][__name__][time][hour]", "collection_date_time[tags][__name__][time][minute]"],
+                    "required_group": ["collection_date_time_form[tags][__name__][date][month]", "collection_date_time_form[tags][__name__][date][day]", "collection_date_time_form[tags][__name__][time][hour]", "collection_date_time_form[tags][__name__][time][minute]"],
                     "required": {
                         depends: function () {
                             return (validator.settings.validation_groups["Default"]);
@@ -62,70 +62,70 @@ class TotalFormTest extends FormTestCase
                         "required": "This\x20value\x20should\x20not\x20be\x20blank."
                     }
                 });
-                form.find("*[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D\"]").rules("add", {
                     "min": {
                         param: 1,
                         depends: function () {
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
                         }
                     }, "max": {
                         param: 12, depends: function () {
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
                         }
                     }, "messages": {"min": "This\x20value\x20is\x20not\x20valid.", "max": "This\x20value\x20is\x20not\x20valid."}
                 });
-                form.find("*[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bday\x5D\"]").rules("add", {
                     "min": {
                         param: 1,
                         depends: function () {
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
                                 return false;
                             }
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
                         }
                     }, "max": {
                         param: 31, depends: function () {
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Byear\x5D" in validator.invalid)) {
                                 return false;
                             }
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Bdate\x5D\x5Bmonth\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
                         }
                     }, "messages": {"min": "This\x20value\x20is\x20not\x20valid.", "max": "This\x20value\x20is\x20not\x20valid."}
                 });
-                form.find("*[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D\"]").rules("add", {
                     "min": 0,
                     "max": 23,
-                    "required_group": ["collection_date_time[tags][__name__][time][minute]"],
+                    "required_group": ["collection_date_time_form[tags][__name__][time][minute]"],
                     "messages": {
                         "min": "This\x20value\x20is\x20not\x20valid.",
                         "max": "This\x20value\x20is\x20not\x20valid.",
                         "required_group": "This\x20value\x20is\x20not\x20valid."
                     }
                 });
-                form.find("*[name=\"collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bminute\x5D\"]").rules("add", {
+                form.find("*[name=\"collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bminute\x5D\"]").rules("add", {
                     "min": {
                         param: 0,
                         depends: function () {
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
                         }
                     }, "max": {
                         param: 59, depends: function () {
-                            if (("collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.errorMap || "collection_date_time\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.invalid)) {
+                            if (("collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.errorMap || "collection_date_time_form\x5Btags\x5D\x5B__name__\x5D\x5Btime\x5D\x5Bhour\x5D" in validator.invalid)) {
                                 return false;
                             }
                             return true;
@@ -541,25 +541,25 @@ class TotalFormTest extends FormTestCase
         $this->assertEqualJs('
             (function ($) {
                 "use strict";
-                var form = $("form[name=\"additional_rules\"]");
+                var form = $("form[name=\"additional_rules_form\"]");
                 var validator = form.validate({
                     rules: {
-                        "additional_rules\x5Bipv4\x5D": {"ipv4": true},
-                        "additional_rules\x5Bipv6\x5D": {"ipv6": true},
-                        "additional_rules\x5Bipv4_ipv6\x5D": {"one_or_other": {"ipv4": true, "ipv6": true}},
-                        "additional_rules\x5Biban\x5D": {"iban": true},
-                        "additional_rules\x5Bluhn\x5D": {"luhn": true},
-                        "additional_rules\x5Bfile\x5D": {"accept": "text\/plain,application\/pdf"},
-                        "additional_rules\x5Bpattern\x5D": {"pattern": "[a-zA-Z]+"}
+                        "additional_rules_form\x5Bipv4\x5D": {"ipv4": true},
+                        "additional_rules_form\x5Bipv6\x5D": {"ipv6": true},
+                        "additional_rules_form\x5Bipv4_ipv6\x5D": {"one_or_other": {"ipv4": true, "ipv6": true}},
+                        "additional_rules_form\x5Biban\x5D": {"iban": true},
+                        "additional_rules_form\x5Bluhn\x5D": {"luhn": true},
+                        "additional_rules_form\x5Bfile\x5D": {"accept": "text\/plain,application\/pdf"},
+                        "additional_rules_form\x5Bpattern\x5D": {"pattern": "[a-zA-Z]+"}
                     },
                     messages: {
-                        "additional_rules\x5Bipv4\x5D": {"ipv4": "This\x20is\x20not\x20a\x20valid\x20IP\x20address."},
-                        "additional_rules\x5Bipv6\x5D": {"ipv6": "This\x20is\x20not\x20a\x20valid\x20IP\x20address."},
-                        "additional_rules\x5Bipv4_ipv6\x5D": {"one_or_other": "This\x20is\x20not\x20a\x20valid\x20IP\x20address."},
-                        "additional_rules\x5Biban\x5D": {"iban": "This\x20is\x20not\x20a\x20valid\x20International\x20Bank\x20Account\x20Number\x20\x28IBAN\x29."},
-                        "additional_rules\x5Bluhn\x5D": {"luhn": "Invalid\x20card\x20number."},
-                        "additional_rules\x5Bfile\x5D": {"accept": "The\x20mime\x20type\x20of\x20the\x20file\x20is\x20invalid\x20\x28\x7B\x7B\x20type\x20\x7D\x7D\x29.\x20Allowed\x20mime\x20types\x20are\x20text\x2Fplain,\x20application\x2Fpdf."},
-                        "additional_rules\x5Bpattern\x5D": {"pattern": "This\x20value\x20is\x20not\x20valid."}
+                        "additional_rules_form\x5Bipv4\x5D": {"ipv4": "This\x20is\x20not\x20a\x20valid\x20IP\x20address."},
+                        "additional_rules_form\x5Bipv6\x5D": {"ipv6": "This\x20is\x20not\x20a\x20valid\x20IP\x20address."},
+                        "additional_rules_form\x5Bipv4_ipv6\x5D": {"one_or_other": "This\x20is\x20not\x20a\x20valid\x20IP\x20address."},
+                        "additional_rules_form\x5Biban\x5D": {"iban": "This\x20is\x20not\x20a\x20valid\x20International\x20Bank\x20Account\x20Number\x20\x28IBAN\x29."},
+                        "additional_rules_form\x5Bluhn\x5D": {"luhn": "Invalid\x20card\x20number."},
+                        "additional_rules_form\x5Bfile\x5D": {"accept": "The\x20mime\x20type\x20of\x20the\x20file\x20is\x20invalid\x20\x28\x7B\x7B\x20type\x20\x7D\x7D\x29.\x20Allowed\x20mime\x20types\x20are\x20text\x2Fplain,\x20application\x2Fpdf."},
+                        "additional_rules_form\x5Bpattern\x5D": {"pattern": "This\x20value\x20is\x20not\x20valid."}
                     }
                 });
             })(jQuery);',

--- a/tests/Functional/features/bootstrap/FeatureContext.php
+++ b/tests/Functional/features/bootstrap/FeatureContext.php
@@ -2,6 +2,7 @@
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Behat\Hook\Scope\BeforeFeatureScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\WebAssert;
 use Behat\MinkExtension\Context\MinkAwareContext;
@@ -191,5 +192,16 @@ class FeatureContext extends RawMinkContext implements Context, SnippetAccepting
     public function iWaitForJQueryToBeActive()
     {
         $this->getSession()->wait(5000, '(0 === jQuery.active)');
+    }
+
+    /**
+     * @BeforeFeature @constraintIsTrueExists
+     */
+    public static function beforeFeatureTagged() {
+        if (class_exists('Symfony\Component\Validator\Constraints\IsTrue', true)) {
+            return;
+        }
+
+        throw new \RuntimeException('Skipping because the IsTrue constraint is not existing');
     }
 }

--- a/tests/Functional/features/button_validation_groups.feature
+++ b/tests/Functional/features/button_validation_groups.feature
@@ -5,11 +5,11 @@ Feature: Testing validation groups based on the button that is pressed
       And I wait for jQuery to be active
 
   Scenario Outline: I can submit a valid form instance
-    When I fill in the "buttons" form with the following:
+    When I fill in the "buttons_form" form with the following:
       | title   | John Doe     |
       | content | -            |
-    And I submit "buttons" by clicking on "<button>"
-    Then I should see no validation errors in the "buttons" form
+    And I submit "buttons_form" by clicking on "<button>"
+    Then I should see no validation errors in the "buttons_form" form
 
     Examples:
       | button                   |
@@ -19,19 +19,19 @@ Feature: Testing validation groups based on the button that is pressed
       | noValidation             |
 
   Scenario: I can always submit a form when validation groups is false
-    When I fill in the "buttons" form with the following:
+    When I fill in the "buttons_form" form with the following:
       | title   | |
       | content | |
-    And I submit "buttons" by clicking on "noValidation"
-    Then I should see no validation errors in the "buttons" form
+    And I submit "buttons_form" by clicking on "noValidation"
+    Then I should see no validation errors in the "buttons_form" form
 
   # NotBlank => [ 'groups' => [ 'main', 'Default' ] ]
   Scenario Outline: I can have constraints that have multiple validation groups
-    When I fill in the "buttons" form with the following:
+    When I fill in the "buttons_form" form with the following:
       | title   |              |
       | content | some content |
-    And I submit "buttons" by clicking on "<button>"
-    Then I should only see the following validation errors in the "buttons" form:
+    And I submit "buttons_form" by clicking on "<button>"
+    Then I should only see the following validation errors in the "buttons_form" form:
       | title | This value should not be blank. |
 
     Examples:
@@ -42,11 +42,11 @@ Feature: Testing validation groups based on the button that is pressed
 
   # Length => [ 'groups' => 'main' ]
   Scenario Outline: I can have a constraint that is only used by a single group (main)
-    When I fill in the "buttons" form with the following:
+    When I fill in the "buttons_form" form with the following:
       | title   | a            |
       | content | some content |
-    And I submit "buttons" by clicking on "<button>"
-    Then I should only see the following validation errors in the "buttons" form:
+    And I submit "buttons_form" by clicking on "<button>"
+    Then I should only see the following validation errors in the "buttons_form" form:
       | title | This value is too short. It should have 8 characters or more. |
 
     Examples:
@@ -55,19 +55,19 @@ Feature: Testing validation groups based on the button that is pressed
       | mainAndDefaultValidation |
 
   Scenario: I can submit when a constraint is invalid but not I my group (main)
-    When I fill in the "buttons" form with the following:
+    When I fill in the "buttons_form" form with the following:
       | title   | a            |
       | content | some content |
-    And I submit "buttons" by clicking on "defaultValidation"
-    Then I should see no validation errors in the "buttons" form
+    And I submit "buttons_form" by clicking on "defaultValidation"
+    Then I should see no validation errors in the "buttons_form" form
 
   # Length => [ 'groups' => 'Default' ]
   Scenario Outline: I can have a constraint that is only used by a single group (main)
-    When I fill in the "buttons" form with the following:
+    When I fill in the "buttons_form" form with the following:
       | title   | John Doe |
       | content |          |
-    And I submit "buttons" by clicking on "<button>"
-    Then I should only see the following validation errors in the "buttons" form:
+    And I submit "buttons_form" by clicking on "<button>"
+    Then I should only see the following validation errors in the "buttons_form" form:
       | content | This value should not be blank. |
 
     Examples:
@@ -76,8 +76,8 @@ Feature: Testing validation groups based on the button that is pressed
       | mainAndDefaultValidation |
 
   Scenario: I can submit when a constraint is invalid but not I my group (main)
-    When I fill in the "buttons" form with the following:
+    When I fill in the "buttons_form" form with the following:
       | title   | John Doe |
       | content |          |
-    And I submit "buttons" by clicking on "mainValidation"
-    Then I should see no validation errors in the "buttons" form
+    And I submit "buttons_form" by clicking on "mainValidation"
+    Then I should see no validation errors in the "buttons_form" form

--- a/tests/Functional/features/is_true_or_false.feature
+++ b/tests/Functional/features/is_true_or_false.feature
@@ -1,3 +1,4 @@
+@constraintIsTrueExists
 Feature: Testing validation using IsTrue or IsFalse constraints
 
   Background:
@@ -5,7 +6,7 @@ Feature: Testing validation using IsTrue or IsFalse constraints
       And I wait for jQuery to be active
 
   Scenario: I can submit a valid form instance
-    When I fill in the "isTrueOrFalse" form with the following:
+    When I fill in the "is_true_or_false_form" form with the following:
       | check-true       | 1 |
       | select-bool-true | 1 |
       | select-int-true  | 1 |
@@ -13,12 +14,12 @@ Feature: Testing validation using IsTrue or IsFalse constraints
       | check-false      | 0 |
       | select-false     | 0 |
       | text-false       | 0 |
-    And I submit "isTrueOrFalse"
-    Then I should see no validation errors in the "isTrueOrFalse" form
+    And I submit "is_true_or_false_form"
+    Then I should see no validation errors in the "is_true_or_false_form" form
 
   @clientSide @basic
   Scenario: I see only checkbox isTrue errors when additionals are not enabled
-    When I fill in the "isTrueOrFalse" form with the following:
+    When I fill in the "is_true_or_false_form" form with the following:
       | check-true       | 0     |
       | select-bool-true | 0     |
       | select-int-true  | 0     |
@@ -26,13 +27,13 @@ Feature: Testing validation using IsTrue or IsFalse constraints
       | check-false      | 1     |
       | select-false     | 1     |
       | text-false       | false |
-    And I submit "isTrueOrFalse"
-    Then I should only see the following validation errors in the "isTrueOrFalse" form:
+    And I submit "is_true_or_false_form"
+    Then I should only see the following validation errors in the "is_true_or_false_form" form:
       | check-true       | This value should be true.  |
 
   @additionals @server-side
   Scenario: I see errors when the value is not what is expected additional
-    When I fill in the "isTrueOrFalse" form with the following:
+    When I fill in the "is_true_or_false_form" form with the following:
       | check-true       | 0     |
       | select-bool-true | 0     |
       | select-int-true  | 0     |
@@ -40,8 +41,8 @@ Feature: Testing validation using IsTrue or IsFalse constraints
       | check-false      | 1     |
       | select-false     | 1     |
       | text-false       | false |
-    And I submit "isTrueOrFalse"
-    Then I should only see the following validation errors in the "isTrueOrFalse" form:
+    And I submit "is_true_or_false_form"
+    Then I should only see the following validation errors in the "is_true_or_false_form" form:
       | check-true       | This value should be true.  |
       | select-bool-true | This value should be true.  |
       | select-int-true  | This value should be true.  |

--- a/tests/Functional/features/simple_form_data.feature
+++ b/tests/Functional/features/simple_form_data.feature
@@ -5,36 +5,36 @@ Feature: Testing a simple form with constraint fetched form a data object
       And I wait for jQuery to be active
 
   Scenario: I can submit a valid form instance
-    When I fill in the "simple_form_data" form with the following:
+    When I fill in the "simple_data_form" form with the following:
       | name            | John Doe            |
       | password first  | aVerySecretPassword |
       | password second | aVerySecretPassword |
-    And I submit "simple_form_data"
-    Then I should see no validation errors in the "simple_form_data" form
+    And I submit "simple_data_form"
+    Then I should see no validation errors in the "simple_data_form" form
 
   Scenario: Both name and password are required
-    When I submit "simple_form_data"
-    Then I should only see the following validation errors in the "simple_form_data" form:
+    When I submit "simple_data_form"
+    Then I should only see the following validation errors in the "simple_data_form" form:
       | name           | This value should not be blank. |
       | password first | This value should not be blank. |
 
   Scenario: Name and password must have atleast 2 chars
-    When I fill in the "simple_form_data" form with the following:
+    When I fill in the "simple_data_form" form with the following:
       | name            | a |
       | password first  | a |
       | password second | a |
-    And I submit "simple_form_data"
-    Then I should only see the following validation errors in the "simple_form_data" form:
+    And I submit "simple_data_form"
+    Then I should only see the following validation errors in the "simple_data_form" form:
       | name           | This value is too short. It should have 2 characters or more. |
       | password first | This value is too short. It should have 2 characters or more. |
 
   Scenario: Name and password may not be longer then 255 chars
-    When I fill in the "simple_form_data" form field with a string of length 256 the following:
+    When I fill in the "simple_data_form" form field with a string of length 256 the following:
       | name            |
       | password first  |
       | password second |
-    And I submit "simple_form_data"
-    Then I should only see the following validation errors in the "simple_form_data" form:
+    And I submit "simple_data_form"
+    Then I should only see the following validation errors in the "simple_data_form" form:
       | name           | This value is too long. It should have 255 characters or less. |
       | password first | This value is too long. It should have 255 characters or less. |
 
@@ -47,22 +47,22 @@ Feature: Testing a simple form with constraint fetched form a data object
   # This is different from Symfony because symfony will first apply a transformer and then the constraints.
   @clientSide
   Scenario: Name and password must have atleast 2 chars
-    When I fill in the "simple_form_data" form with the following:
+    When I fill in the "simple_data_form" form with the following:
       | name            | John |
       | password first  | a    |
       | password second |      |
-    And I submit "simple_form_data"
-    Then I should only see the following validation errors in the "simple_form_data" form:
+    And I submit "simple_data_form"
+    Then I should only see the following validation errors in the "simple_data_form" form:
       | password first | This value is too short. It should have 2 characters or more. |
 
   @serverSide
   Scenario: Name and password must have atleast 2 chars
-    When I fill in the "simple_form_data" form with the following:
+    When I fill in the "simple_data_form" form with the following:
       | name            | John |
       | password first  | a    |
       | password second |      |
-    And I submit "simple_form_data"
-    Then I should only see the following validation errors in the "simple_form_data" form:
+    And I submit "simple_data_form"
+    Then I should only see the following validation errors in the "simple_data_form" form:
       | password first  | This value is not valid. |
 
   # # EqualTo
@@ -70,20 +70,20 @@ Feature: Testing a simple form with constraint fetched form a data object
   # but it is applied on the compound/first field by Symfony
   @clientSide
   Scenario: Password must match
-    When I fill in the "simple_form_data" form with the following:
+    When I fill in the "simple_data_form" form with the following:
       | name            | John Doe            |
       | password first  | aVerySecretPassword |
       | password second |                     |
-    And I submit "simple_form_data"
-    Then I should only see the following validation errors in the "simple_form_data" form:
+    And I submit "simple_data_form"
+    Then I should only see the following validation errors in the "simple_data_form" form:
       | password second  | This value is not valid. |
 
   @serverSide
   Scenario: Password must match
-    When I fill in the "simple_form_data" form with the following:
+    When I fill in the "simple_data_form" form with the following:
       | name            | John Doe            |
       | password first  | aVerySecretPassword |
       | password second |                     |
-    And I submit "simple_form_data"
-    Then I should only see the following validation errors in the "simple_form_data" form:
+    And I submit "simple_data_form"
+    Then I should only see the following validation errors in the "simple_data_form" form:
       | password first  | This value is not valid. |

--- a/tests/Unit/Form/Rule/Mapping/MaxLengthRuleTest.php
+++ b/tests/Unit/Form/Rule/Mapping/MaxLengthRuleTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Boekkooi\Bundle\JqueryValidationBundle\Form\Rule\Mapping;
 use Boekkooi\Bundle\JqueryValidationBundle\Form\Rule\ConstraintRule;
 use Boekkooi\Bundle\JqueryValidationBundle\Form\Rule\Mapping\MaxLengthRule;
 use Boekkooi\Bundle\JqueryValidationBundle\Form\RuleMessage;
+use Symfony\Component\Form\ResolvedFormTypeInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints;
 
@@ -22,7 +23,7 @@ class MaxLengthRuleTest extends BaseConstraintMapperTest
 
     protected function setUpBaseTest()
     {
-        $this->given_form_is_of_type('text');
+        $this->given_form_is_of_type('Symfony\Component\Form\Extension\Core\Type\TextType');
     }
 
     /**
@@ -30,9 +31,9 @@ class MaxLengthRuleTest extends BaseConstraintMapperTest
      */
     public function it_should_not_support_length_constraint_for_choice_form_type()
     {
-        $this->given_form_is_of_type('choice');
+        $this->given_form_is_of_type('Symfony\Component\Form\Extension\Core\Type\ChoiceType');
 
-        $this->assertFalse($this->execute_supports(new Constraints\Length(array('max' => 1))));
+        self::assertFalse($this->execute_supports(new Constraints\Length(array('max' => 1))));
     }
 
     public function provide_supported_constraints()
@@ -71,11 +72,18 @@ class MaxLengthRuleTest extends BaseConstraintMapperTest
     public function given_form_is_of_type($type)
     {
         $typeMock = $this->getMock('Symfony\Component\Form\ResolvedFormTypeInterface');
-        $typeMock->expects($this->any())->method('getName')->willReturn($type);
+        $innerType = new $type();
+
+        if (method_exists('Symfony\Component\Form\ResolvedFormTypeInterface', 'getInnerType')) {
+            $typeMock->expects(self::any())->method('getInnerType')->willReturn($innerType);
+        }
+        if (method_exists('Symfony\Component\Form\ResolvedFormTypeInterface', 'getName')) {
+            $typeMock->expects(self::any())->method('getName')->willReturn($innerType->getName());
+        }
 
         $formConfigMock = $this->getMock('Symfony\Component\Form\FormConfigInterface');
-        $formConfigMock->expects($this->any())->method('getType')->willReturn($typeMock);
+        $formConfigMock->expects(self::any())->method('getType')->willReturn($typeMock);
 
-        $this->form->expects($this->any())->method('getConfig')->willReturn($formConfigMock);
+        $this->form->expects(self::any())->method('getConfig')->willReturn($formConfigMock);
     }
 }

--- a/tests/Unit/Form/Rule/Mapping/MinLengthRuleTest.php
+++ b/tests/Unit/Form/Rule/Mapping/MinLengthRuleTest.php
@@ -22,7 +22,7 @@ class MinLengthRuleTest extends BaseConstraintMapperTest
 
     protected function setUpBaseTest()
     {
-        $this->given_form_is_of_type('text');
+        $this->given_form_is_of_type('Symfony\Component\Form\Extension\Core\Type\TextType');
     }
 
     /**
@@ -30,9 +30,9 @@ class MinLengthRuleTest extends BaseConstraintMapperTest
      */
     public function it_should_not_support_length_constraint_for_choice_form_type()
     {
-        $this->given_form_is_of_type('choice');
+        $this->given_form_is_of_type('Symfony\Component\Form\Extension\Core\Type\ChoiceType');
 
-        $this->assertFalse($this->execute_supports(new Constraints\Length(array('min' => 1))));
+        self::assertFalse($this->execute_supports(new Constraints\Length(array('min' => 1))));
     }
 
     public function provide_supported_constraints()
@@ -71,11 +71,18 @@ class MinLengthRuleTest extends BaseConstraintMapperTest
     public function given_form_is_of_type($type)
     {
         $typeMock = $this->getMock('Symfony\Component\Form\ResolvedFormTypeInterface');
-        $typeMock->expects($this->any())->method('getName')->willReturn($type);
+        $innerType = new $type();
+
+        if (method_exists('Symfony\Component\Form\ResolvedFormTypeInterface', 'getInnerType')) {
+            $typeMock->expects(self::any())->method('getInnerType')->willReturn($innerType);
+        }
+        if (method_exists('Symfony\Component\Form\ResolvedFormTypeInterface', 'getName')) {
+            $typeMock->expects(self::any())->method('getName')->willReturn($innerType->getName());
+        }
 
         $formConfigMock = $this->getMock('Symfony\Component\Form\FormConfigInterface');
-        $formConfigMock->expects($this->any())->method('getType')->willReturn($typeMock);
+        $formConfigMock->expects(self::any())->method('getType')->willReturn($typeMock);
 
-        $this->form->expects($this->any())->method('getConfig')->willReturn($formConfigMock);
+        $this->form->expects(self::any())->method('getConfig')->willReturn($formConfigMock);
     }
 }


### PR DESCRIPTION
This PR adds Symfony 3 support to the bundle.

This updates the test code to be Symfony 3 valid and uses the TypeHelper to downgrade to Symfony 2 compatibility.

This PR can't yet be merged because we depend on [behat/symfony2-extension](https://packagist.org/packages/behat/symfony2-extension) for testing and this is not yet compatibility with Symfony 3 (see https://github.com/Behat/Symfony2Extension/pull/95).