### PR TITLE
Fixes simple form with validation groups and buttons inside

### DIFF
--- a/src/Resources/views/Form/form_validate.js.twig
+++ b/src/Resources/views/Form/form_validate.js.twig
@@ -22,7 +22,7 @@
             form.find("*[name=\"{{ button.name|e('js') }}\"]").addClass("cancel");
         {%- elseif enforce_validation_groups -%}
             form.find("*[name=\"{{ button.name|e('js') }}\"]").click(function() {
-                validator.settings.validation_groups = { {{- gen.validation_groups(validation_groups, button.validation_groups) -}} };
+                validator.settings.validation_groups = { {{- gen.validation_groups(validation_groups, enabled_validation_groups) -}} };
             });
         {%- endif -%}
     {%- endfor %}

--- a/src/Twig/JqueryValidationExtension.php
+++ b/src/Twig/JqueryValidationExtension.php
@@ -58,7 +58,7 @@ class JqueryValidationExtension extends Twig_Extension
             'validation_groups' => $this->validationGroupsViewData($rootContext),
         );
         $templateVars['enforce_validation_groups'] = count($templateVars['validation_groups']) > 1;
-        $templateVars['enabled_validation_groups'] = count($rootContext->getButtons()) === 0 ? $templateVars['validation_groups'] : array();
+        $templateVars['enabled_validation_groups'] = $templateVars['validation_groups'];
 
         // Only add buttons from the root form
         if ($view->parent === null) {


### PR DESCRIPTION
Because of [this line](https://github.com/boekkooi/JqueryValidationBundle/blob/master/src/Twig/JqueryValidationExtension.php#L61) simple form with button and model with asserts with validation groups will not work.

$enabled_validation_groups will be empty array because form has button.

I fixed it but maybe it breaks BC with other bundles. Please check it