### PR TITLE
Change document ready for compatibility mode with other libraries

### DIFF
--- a/src/Resources/views/Form/dynamic_validate.js.twig
+++ b/src/Resources/views/Form/dynamic_validate.js.twig
@@ -1,7 +1,7 @@
 {% import "BoekkooiJqueryValidationBundle:Form:macros.js.twig" as gen %}
 
 {%- autoescape false -%}
-(function($) {
+jQuery(function($) {
     "use strict";
     var form = $("{{- gen.form_jquery_selector(form) -}}");
     var validator = form.validate();
@@ -13,5 +13,5 @@
             });
         {%- endif -%}
     {%- endfor -%}
-})(jQuery);
+});
 {%- endautoescape -%}

--- a/src/Resources/views/Form/form_validate.js.twig
+++ b/src/Resources/views/Form/form_validate.js.twig
@@ -1,7 +1,7 @@
 {% import "BoekkooiJqueryValidationBundle:Form:macros.js.twig" as gen %}
 
 {%- autoescape false -%}
-(function($) {
+jQuery(function($) {
     "use strict";
     var form = $("{{- gen.form_jquery_selector(form) -}}");
     var validator = form.validate({
@@ -26,5 +26,5 @@
             });
         {%- endif -%}
     {%- endfor %}
-})(jQuery);
+});
 {%- endautoescape -%}


### PR DESCRIPTION
When using different libraries, the generated script can trigger the error "jquery.validate is not a function" in some scenarios.

By changing `(function($){})(jQuery)` to `jQuery(function($){})`, the problem is corrected.

Affected version:
jquery version: v3.1.1
jquery validation plugin: v1.16.0

* Checked if jQuery library was loaded only 1 time.


